### PR TITLE
feat(eval): define stable evaluation report schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,3 +256,22 @@ vrs/
 ├── pipeline.py    Single-stream cascade orchestration
 └── schemas.py     Frame / Detection / CandidateAlert / VerifiedAlert
 ```
+
+## Evaluation Reports
+
+`scripts/eval.py` writes `<out>/report.json` using the stable schema version
+`vrs.eval.report.v1`.
+
+Top-level sections:
+- `schema_version` — explicit report-contract identifier for compatibility checks.
+- `run` — dataset name, run ID, timestamp, mode, and config/policy paths.
+- `models` — detector and verifier backend/model identifiers from the active config.
+- `metrics` — overall and per-class precision, recall, F1, TP, FP, and FN.
+- `latency` — reserved stable slots for detector/verifier latency percentiles.
+- `runtime` — lightweight environment metadata such as Python version.
+- `quality_signals` — verifier flip rate, false-negative flag rate, and reserved diagnostic slots.
+- `per_video` — optional per-clip breakdown using the same metrics/quality shape.
+
+Today the CLI emits `mode: "full_cascade"` for the current detector+verifier
+path. A future detector-only scoring mode can reuse the same report schema with
+`mode: "detector_only"` instead of changing the JSON contract again.

--- a/README.md
+++ b/README.md
@@ -275,3 +275,8 @@ Top-level sections:
 Today the CLI emits `mode: "full_cascade"` for the current detector+verifier
 path. A future detector-only scoring mode can reuse the same report schema with
 `mode: "detector_only"` instead of changing the JSON contract again.
+
+`run.created_at` and `runtime.*` are diagnostic — they vary across runs and
+machines and are not part of the regression contract. The CI gate
+(`python -m vrs.eval.ci`) only compares `metrics` and `quality_signals`, so
+committed baselines are immune to clock and Python-version drift.

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -10,19 +10,19 @@ Example:
 
 Layout of the dataset directory — see vrs.eval.datasets.labeled_dir for the
 sidecar-JSON schema. Each video gets its own subdir under ``--out`` holding
-its ``alerts.jsonl`` and event thumbnails. A single ``report.json`` with
-per-video + aggregate metrics lands at ``--out`` (or the path given via
-``--report``).
+its ``alerts.jsonl`` and event thumbnails. A single versioned ``report.json``
+lands at ``--out`` (or the path given via ``--report``).
 """
 from __future__ import annotations
 
 import argparse
-import json
 import logging
 from pathlib import Path
 
+import yaml
+
 from vrs import setup_logging
-from vrs.eval import evaluate
+from vrs.eval import EvalReport, evaluate
 from vrs.eval.datasets import LabeledDirDataset
 
 logger = logging.getLogger(__name__)
@@ -58,7 +58,16 @@ def main() -> None:
 
     report_path = Path(args.report) if args.report else Path(args.out) / "report.json"
     report_path.parent.mkdir(parents=True, exist_ok=True)
-    report_path.write_text(json.dumps(result.to_dict(), indent=2), encoding="utf-8")
+    with open(args.config, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f) or {}
+    report = EvalReport.from_harness_result(
+        result,
+        dataset=args.dataset,
+        config_path=args.config,
+        policy_path=args.policy,
+        config=config,
+    )
+    report.write(report_path)
 
     agg = result.aggregate
     overall = agg.overall().to_dict()

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -2,15 +2,19 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
 from vrs.eval import (
     ClassMetrics,
+    EvalReport,
     EvalItem,
     GroundTruthEvent,
+    HarnessResult,
     RunScore,
+    SCHEMA_VERSION,
     score_alerts_against_truth,
 )
 from vrs.eval.datasets import LabeledDirDataset
@@ -240,6 +244,56 @@ def test_harness_scores_per_video_and_aggregates(tmp_path: Path):
     assert "aggregate" in blob and "per_video" in blob
 
 
+def test_eval_report_round_trip_is_stable():
+    score = score_alerts_against_truth(
+        [
+            _alert("smoke", 8.0, true_alert=False, fn_cls="smoke"),
+            _alert("fire", 2.0, true_alert=True),
+        ],
+        [
+            _event("fire", 1.0, 3.0),
+            _event("smoke", 7.0, 9.0),
+        ],
+        tolerance_s=0.0,
+    )
+    result = HarnessResult(
+        aggregate=score,
+        per_video=[
+            (Path("b.mp4"), score),
+            (Path("a.mp4"), score),
+        ],
+    )
+    report = EvalReport.from_harness_result(
+        result,
+        dataset="fixtures/mini-dataset",
+        config_path="configs/default.yaml",
+        policy_path="configs/policies/safety.yaml",
+        config={
+            "detector": {"backend": "ultralytics", "model": "yoloe-11l-seg.pt"},
+            "verifier": {
+                "enabled": True,
+                "backend": "transformers",
+                "model_id": "nvidia/Cosmos-Reason2-2B",
+            },
+        },
+        created_at=datetime(2026, 4, 26, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert report.schema_version == SCHEMA_VERSION
+    assert report.run.mode == "full_cascade"
+    assert report.run.run_id == "2026-04-26-mini-dataset-yoloe-11l-seg-cosmos-reason2-2b"
+    assert [entry.video for entry in report.per_video] == ["a.mp4", "b.mp4"]
+    assert report.metrics.overall.tp == 1
+    assert report.metrics.per_class["fire"].f1 == pytest.approx(1.0)
+    assert report.quality_signals.verifier_flip_rate == pytest.approx(0.5)
+    assert report.quality_signals.false_negative_flag_rate == pytest.approx(0.5)
+
+    payload = report.to_dict()
+    assert list(payload["metrics"]["per_class"].keys()) == ["fire", "smoke"]
+    assert EvalReport.from_dict(payload) == report
+    assert json.loads(report.to_json()) == payload
+
+
 def _report(per_class: dict[str, float], overall_f1: float = 0.0,
             flip_rate: float = 0.0, fn_flag_rate: float = 0.0) -> dict:
     """Minimal report.json-shaped fixture — f1-only per class, all other
@@ -317,6 +371,79 @@ def test_gate_treats_missing_class_in_current_as_regression():
     assert smoke.regressed is True
     assert "missing" in smoke.note
     assert result.passed is False
+
+
+def _schema_v1_report(
+    per_class: dict[str, float],
+    *,
+    overall_f1: float = 0.0,
+    flip_rate: float = 0.0,
+    fn_flag_rate: float = 0.0,
+) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run": {
+            "run_id": "2026-04-26-mini-dataset-yoloe-11l-seg-cosmos-reason2-2b",
+            "created_at": "2026-04-26T00:00:00Z",
+            "dataset": "mini-dataset",
+            "mode": "full_cascade",
+            "policy_path": "configs/policies/safety.yaml",
+            "config_path": "configs/default.yaml",
+        },
+        "models": {
+            "detector": {"backend": "ultralytics", "model": "yoloe-11l-seg.pt"},
+            "verifier": {"backend": "transformers", "model": "nvidia/Cosmos-Reason2-2B"},
+        },
+        "metrics": {
+            "per_class": {
+                cls: {"tp": 0, "fp": 0, "fn": 0,
+                      "precision": 0.0, "recall": 0.0, "f1": f1}
+                for cls, f1 in per_class.items()
+            },
+            "overall": {"tp": 0, "fp": 0, "fn": 0,
+                        "precision": 0.0, "recall": 0.0, "f1": overall_f1},
+        },
+        "latency": {
+            "detector_p50_ms": None,
+            "detector_p95_ms": None,
+            "verifier_p50_ms": None,
+            "verifier_p95_ms": None,
+        },
+        "runtime": {
+            "python": None,
+            "torch": None,
+            "cuda": None,
+            "gpu_name": None,
+            "peak_vram_mb": None,
+        },
+        "quality_signals": {
+            "verifier_flip_rate": flip_rate,
+            "false_negative_flag_rate": fn_flag_rate,
+            "malformed_json_rate": None,
+            "queue_drops": None,
+        },
+        "per_video": [],
+    }
+
+
+def test_gate_reads_schema_v1_reports():
+    from vrs.eval.ci import compare_reports
+    baseline = _schema_v1_report({"fire": 0.80}, overall_f1=0.80, flip_rate=0.10)
+    current = _schema_v1_report({"fire": 0.78}, overall_f1=0.78, flip_rate=0.12)
+    result = compare_reports(baseline, current, max_f1_drop=0.05)
+    assert result.passed is True
+    assert result.baseline_flip_rate == pytest.approx(0.10)
+    assert result.current_flip_rate == pytest.approx(0.12)
+
+
+def test_gate_supports_legacy_vs_schema_v1_reports():
+    from vrs.eval.ci import compare_reports
+    baseline = _report({"fire": 0.80}, overall_f1=0.80, flip_rate=0.10, fn_flag_rate=0.01)
+    current = _schema_v1_report({"fire": 0.70}, overall_f1=0.70, flip_rate=0.20, fn_flag_rate=0.03)
+    result = compare_reports(baseline, current, max_f1_drop=0.05)
+    assert result.passed is False
+    assert result.overall.regressed is True
+    assert result.current_fn_flag_rate == pytest.approx(0.03)
 
 
 def test_gate_welcomes_new_class_in_current():

--- a/vrs/eval/__init__.py
+++ b/vrs/eval/__init__.py
@@ -18,6 +18,19 @@ from __future__ import annotations
 
 from .harness import HarnessResult, evaluate
 from .metrics import aggregate_scores, score_alerts_against_truth
+from .report import (
+    EvalReport,
+    PerVideoReport,
+    ReportClassMetrics,
+    ReportLatency,
+    ReportMetrics,
+    ReportModel,
+    ReportModels,
+    ReportQualitySignals,
+    ReportRun,
+    ReportRuntime,
+    SCHEMA_VERSION,
+)
 from .schemas import ClassMetrics, EvalItem, GroundTruthEvent, RunScore
 
 # Note: ``ci`` is intentionally not re-exported here — it is a tool module
@@ -27,10 +40,21 @@ from .schemas import ClassMetrics, EvalItem, GroundTruthEvent, RunScore
 
 __all__ = [
     "ClassMetrics",
+    "EvalReport",
     "EvalItem",
     "GroundTruthEvent",
     "HarnessResult",
+    "PerVideoReport",
+    "ReportClassMetrics",
+    "ReportLatency",
+    "ReportMetrics",
+    "ReportModel",
+    "ReportModels",
+    "ReportQualitySignals",
+    "ReportRun",
+    "ReportRuntime",
     "RunScore",
+    "SCHEMA_VERSION",
     "aggregate_scores",
     "evaluate",
     "score_alerts_against_truth",

--- a/vrs/eval/__init__.py
+++ b/vrs/eval/__init__.py
@@ -3,16 +3,18 @@
 Measures cascade quality against labeled datasets so every other tuning
 knob (thresholds, prompts, verifier model, tracking) stops being guesswork.
 
-Current scope (Step 1.A):
+Current scope:
   * Dataclasses for ground-truth events and eval results (``schemas``).
   * Per-class P/R/F1 + verifier-flip rate + FN-flag rate (``metrics``).
-  * One concrete dataset adapter: a directory of mp4 files with sidecar
-    JSON labels (``datasets.labeled_dir``).
+  * Stable, versioned ``EvalReport`` JSON contract (``report``).
+  * Harness that iterates a dataset → runs the cascade → scores
+    (``harness``), with the labeled-directory adapter under ``datasets``.
+  * Regression gate that compares two reports and exits non-zero on F1
+    drops beyond a tolerance (``ci``, run as ``python -m vrs.eval.ci``).
 
 Upcoming:
-  * ``harness.py``  — iterate dataset → run cascade → score.
   * ``datasets/dfire.py`` and ``datasets/le2i.py`` — real public datasets.
-  * ``ci.py``       — regression gate: fail on F1 delta < -0.02.
+  * Detector-only evaluation mode reusing the same report schema.
 """
 from __future__ import annotations
 

--- a/vrs/eval/ci.py
+++ b/vrs/eval/ci.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
@@ -93,13 +94,29 @@ class GateResult:
 
 # ──────────────────────────────────────────────────────────────────────
 
+def _metrics_section(report: Mapping[str, object]) -> Mapping[str, object]:
+    if isinstance(report.get("metrics"), Mapping):
+        return report["metrics"]
+    if isinstance(report.get("aggregate"), Mapping):
+        return report["aggregate"]
+    return {}
+
+
+def _quality_signals_section(report: Mapping[str, object]) -> Mapping[str, object]:
+    if isinstance(report.get("quality_signals"), Mapping):
+        return report["quality_signals"]
+    if isinstance(report.get("aggregate"), Mapping):
+        return report["aggregate"]
+    return {}
+
+
 def _per_class_f1(report: dict) -> Dict[str, float]:
-    per = report.get("aggregate", {}).get("per_class", {})
+    per = _metrics_section(report).get("per_class", {})
     return {cls: float(m.get("f1", 0.0)) for cls, m in per.items()}
 
 
 def _overall_f1(report: dict) -> float:
-    return float(report.get("aggregate", {}).get("overall", {}).get("f1", 0.0))
+    return float(_metrics_section(report).get("overall", {}).get("f1", 0.0))
 
 
 def compare_reports(
@@ -121,8 +138,8 @@ def compare_reports(
     """
     if max_f1_drop < 0:
         raise ValueError("max_f1_drop must be >= 0")
-    if "aggregate" not in baseline or "aggregate" not in current:
-        raise ValueError("both reports must have an 'aggregate' key")
+    if not _metrics_section(baseline) or not _metrics_section(current):
+        raise ValueError("both reports must have either a 'metrics' or 'aggregate' key")
 
     b_pc = _per_class_f1(baseline)
     c_pc = _per_class_f1(current)
@@ -160,18 +177,26 @@ def compare_reports(
         regressed=(bof1 - cof1) > max_f1_drop,
     )
 
-    b_agg = baseline.get("aggregate", {})
-    c_agg = current.get("aggregate", {})
+    b_quality = _quality_signals_section(baseline)
+    c_quality = _quality_signals_section(current)
     passed = not overall.regressed and not any(d.regressed for d in per_class)
     return GateResult(
         passed=passed,
         per_class=per_class,
         overall=overall,
         max_f1_drop=max_f1_drop,
-        baseline_flip_rate=float(b_agg.get("flip_rate", 0.0)),
-        current_flip_rate=float(c_agg.get("flip_rate", 0.0)),
-        baseline_fn_flag_rate=float(b_agg.get("fn_flag_rate", 0.0)),
-        current_fn_flag_rate=float(c_agg.get("fn_flag_rate", 0.0)),
+        baseline_flip_rate=float(
+            b_quality.get("verifier_flip_rate", b_quality.get("flip_rate", 0.0))
+        ),
+        current_flip_rate=float(
+            c_quality.get("verifier_flip_rate", c_quality.get("flip_rate", 0.0))
+        ),
+        baseline_fn_flag_rate=float(
+            b_quality.get("false_negative_flag_rate", b_quality.get("fn_flag_rate", 0.0))
+        ),
+        current_fn_flag_rate=float(
+            c_quality.get("false_negative_flag_rate", c_quality.get("fn_flag_rate", 0.0))
+        ),
     )
 
 

--- a/vrs/eval/report.py
+++ b/vrs/eval/report.py
@@ -55,9 +55,9 @@ class ReportClassMetrics:
             tp=int(metrics.tp),
             fp=int(metrics.fp),
             fn=int(metrics.fn),
-            precision=_round_metric(metrics.precision) or 0.0,
-            recall=_round_metric(metrics.recall) or 0.0,
-            f1=_round_metric(metrics.f1) or 0.0,
+            precision=_round_metric(metrics.precision),
+            recall=_round_metric(metrics.recall),
+            f1=_round_metric(metrics.f1),
         )
 
     @classmethod

--- a/vrs/eval/report.py
+++ b/vrs/eval/report.py
@@ -1,0 +1,442 @@
+"""Stable, versioned evaluation report schema.
+
+The report object is intentionally decoupled from the scoring internals so the
+JSON emitted by ``scripts/eval.py`` stays stable even as the harness gains new
+dataset adapters or scoring modes.
+"""
+from __future__ import annotations
+
+import json
+import platform
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+from .harness import HarnessResult
+from .schemas import ClassMetrics, RunScore
+
+
+SCHEMA_VERSION = "vrs.eval.report.v1"
+
+
+def _round_metric(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return round(float(value), 4)
+
+
+def _slug(value: str | None, *, fallback: str) -> str:
+    raw = (value or "").strip().lower()
+    raw = raw.split("/")[-1]
+    raw = raw.removesuffix(".pt").removesuffix(".engine")
+    slug = re.sub(r"[^a-z0-9]+", "-", raw).strip("-")
+    return slug or fallback
+
+
+def _utc_timestamp(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class ReportClassMetrics:
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
+    precision: float = 0.0
+    recall: float = 0.0
+    f1: float = 0.0
+
+    @classmethod
+    def from_class_metrics(cls, metrics: ClassMetrics) -> "ReportClassMetrics":
+        return cls(
+            tp=int(metrics.tp),
+            fp=int(metrics.fp),
+            fn=int(metrics.fn),
+            precision=_round_metric(metrics.precision) or 0.0,
+            recall=_round_metric(metrics.recall) or 0.0,
+            f1=_round_metric(metrics.f1) or 0.0,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ReportClassMetrics":
+        return cls(
+            tp=int(data.get("tp", 0)),
+            fp=int(data.get("fp", 0)),
+            fn=int(data.get("fn", 0)),
+            precision=float(data.get("precision", 0.0)),
+            recall=float(data.get("recall", 0.0)),
+            f1=float(data.get("f1", 0.0)),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "precision": _round_metric(self.precision),
+            "recall": _round_metric(self.recall),
+            "f1": _round_metric(self.f1),
+            "tp": self.tp,
+            "fp": self.fp,
+            "fn": self.fn,
+        }
+
+
+@dataclass(frozen=True)
+class ReportMetrics:
+    overall: ReportClassMetrics = field(default_factory=ReportClassMetrics)
+    per_class: Dict[str, ReportClassMetrics] = field(default_factory=dict)
+
+    @classmethod
+    def from_run_score(cls, score: RunScore) -> "ReportMetrics":
+        return cls(
+            overall=ReportClassMetrics.from_class_metrics(score.overall()),
+            per_class={
+                name: ReportClassMetrics.from_class_metrics(score.per_class[name])
+                for name in sorted(score.per_class)
+            },
+        )
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ReportMetrics":
+        return cls(
+            overall=ReportClassMetrics.from_dict(data.get("overall", {})),
+            per_class={
+                name: ReportClassMetrics.from_dict(metrics)
+                for name, metrics in sorted((data.get("per_class") or {}).items())
+            },
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "overall": self.overall.to_dict(),
+            "per_class": {
+                name: self.per_class[name].to_dict()
+                for name in sorted(self.per_class)
+            },
+        }
+
+
+@dataclass(frozen=True)
+class ReportLatency:
+    detector_p50_ms: float | None = None
+    detector_p95_ms: float | None = None
+    verifier_p50_ms: float | None = None
+    verifier_p95_ms: float | None = None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ReportLatency":
+        return cls(
+            detector_p50_ms=_round_metric(data.get("detector_p50_ms")),
+            detector_p95_ms=_round_metric(data.get("detector_p95_ms")),
+            verifier_p50_ms=_round_metric(data.get("verifier_p50_ms")),
+            verifier_p95_ms=_round_metric(data.get("verifier_p95_ms")),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "detector_p50_ms": _round_metric(self.detector_p50_ms),
+            "detector_p95_ms": _round_metric(self.detector_p95_ms),
+            "verifier_p50_ms": _round_metric(self.verifier_p50_ms),
+            "verifier_p95_ms": _round_metric(self.verifier_p95_ms),
+        }
+
+
+@dataclass(frozen=True)
+class ReportRuntime:
+    python: str | None = None
+    torch: str | None = None
+    cuda: str | None = None
+    gpu_name: str | None = None
+    peak_vram_mb: float | None = None
+
+    @classmethod
+    def current(cls) -> "ReportRuntime":
+        return cls(python=platform.python_version())
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ReportRuntime":
+        return cls(
+            python=data.get("python"),
+            torch=data.get("torch"),
+            cuda=data.get("cuda"),
+            gpu_name=data.get("gpu_name"),
+            peak_vram_mb=_round_metric(data.get("peak_vram_mb")),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "python": self.python,
+            "torch": self.torch,
+            "cuda": self.cuda,
+            "gpu_name": self.gpu_name,
+            "peak_vram_mb": _round_metric(self.peak_vram_mb),
+        }
+
+
+@dataclass(frozen=True)
+class ReportQualitySignals:
+    verifier_flip_rate: float | None = None
+    false_negative_flag_rate: float | None = None
+    malformed_json_rate: float | None = None
+    queue_drops: int | None = None
+
+    @classmethod
+    def from_run_score(cls, score: RunScore) -> "ReportQualitySignals":
+        return cls(
+            verifier_flip_rate=_round_metric(score.flip_rate),
+            false_negative_flag_rate=_round_metric(score.fn_flag_rate),
+        )
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ReportQualitySignals":
+        queue_drops = data.get("queue_drops")
+        return cls(
+            verifier_flip_rate=_round_metric(data.get("verifier_flip_rate")),
+            false_negative_flag_rate=_round_metric(data.get("false_negative_flag_rate")),
+            malformed_json_rate=_round_metric(data.get("malformed_json_rate")),
+            queue_drops=int(queue_drops) if queue_drops is not None else None,
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "verifier_flip_rate": _round_metric(self.verifier_flip_rate),
+            "false_negative_flag_rate": _round_metric(self.false_negative_flag_rate),
+            "malformed_json_rate": _round_metric(self.malformed_json_rate),
+            "queue_drops": self.queue_drops,
+        }
+
+
+@dataclass(frozen=True)
+class ReportModel:
+    backend: str
+    model: str
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ReportModel":
+        return cls(
+            backend=str(data.get("backend", "")),
+            model=str(data.get("model", "")),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "backend": self.backend,
+            "model": self.model,
+        }
+
+
+@dataclass(frozen=True)
+class ReportModels:
+    detector: ReportModel | None = None
+    verifier: ReportModel | None = None
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any]) -> "ReportModels":
+        det_cfg = config.get("detector") or {}
+        ver_cfg = config.get("verifier") or {}
+
+        detector = None
+        if det_cfg:
+            detector = ReportModel(
+                backend=str(det_cfg.get("backend", "unknown")),
+                model=str(det_cfg.get("model", "unknown")),
+            )
+
+        verifier = None
+        if ver_cfg and ver_cfg.get("enabled", True):
+            verifier = ReportModel(
+                backend=str(ver_cfg.get("backend", "unknown")),
+                model=str(ver_cfg.get("model_id", "unknown")),
+            )
+
+        return cls(detector=detector, verifier=verifier)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ReportModels":
+        detector = data.get("detector")
+        verifier = data.get("verifier")
+        return cls(
+            detector=ReportModel.from_dict(detector) if isinstance(detector, Mapping) else None,
+            verifier=ReportModel.from_dict(verifier) if isinstance(verifier, Mapping) else None,
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "detector": self.detector.to_dict() if self.detector is not None else None,
+            "verifier": self.verifier.to_dict() if self.verifier is not None else None,
+        }
+
+
+@dataclass(frozen=True)
+class ReportRun:
+    run_id: str
+    created_at: str
+    dataset: str
+    mode: str
+    policy_path: str
+    config_path: str
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        dataset: str | Path,
+        policy_path: str | Path,
+        config_path: str | Path,
+        models: ReportModels,
+        verifier_enabled: bool,
+        created_at: datetime | None = None,
+        run_id: str | None = None,
+    ) -> "ReportRun":
+        created = created_at or datetime.now(timezone.utc)
+        detector_slug = _slug(models.detector.model if models.detector else None, fallback="detector")
+        verifier_slug = _slug(models.verifier.model if models.verifier else None, fallback="detector-only")
+        dataset_name = Path(dataset).name
+        return cls(
+            run_id=run_id or f"{created.date().isoformat()}-{_slug(dataset_name, fallback='dataset')}-{detector_slug}-{verifier_slug}",
+            created_at=_utc_timestamp(created),
+            dataset=dataset_name,
+            mode="full_cascade" if verifier_enabled else "detector_only",
+            policy_path=str(policy_path),
+            config_path=str(config_path),
+        )
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ReportRun":
+        return cls(
+            run_id=str(data.get("run_id", "")),
+            created_at=str(data.get("created_at", "")),
+            dataset=str(data.get("dataset", "")),
+            mode=str(data.get("mode", "")),
+            policy_path=str(data.get("policy_path", "")),
+            config_path=str(data.get("config_path", "")),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "run_id": self.run_id,
+            "created_at": self.created_at,
+            "dataset": self.dataset,
+            "mode": self.mode,
+            "policy_path": self.policy_path,
+            "config_path": self.config_path,
+        }
+
+
+@dataclass(frozen=True)
+class PerVideoReport:
+    video: str
+    metrics: ReportMetrics
+    quality_signals: ReportQualitySignals
+
+    @classmethod
+    def from_run_score(cls, video: str | Path, score: RunScore) -> "PerVideoReport":
+        return cls(
+            video=str(video),
+            metrics=ReportMetrics.from_run_score(score),
+            quality_signals=ReportQualitySignals.from_run_score(score),
+        )
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "PerVideoReport":
+        return cls(
+            video=str(data.get("video", "")),
+            metrics=ReportMetrics.from_dict(data.get("metrics", {})),
+            quality_signals=ReportQualitySignals.from_dict(data.get("quality_signals", {})),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "video": self.video,
+            "metrics": self.metrics.to_dict(),
+            "quality_signals": self.quality_signals.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class EvalReport:
+    schema_version: str
+    run: ReportRun
+    models: ReportModels
+    metrics: ReportMetrics
+    latency: ReportLatency
+    runtime: ReportRuntime
+    quality_signals: ReportQualitySignals
+    per_video: Sequence[PerVideoReport] = field(default_factory=tuple)
+
+    @classmethod
+    def from_harness_result(
+        cls,
+        result: HarnessResult,
+        *,
+        dataset: str | Path,
+        config_path: str | Path,
+        policy_path: str | Path,
+        config: Mapping[str, Any] | None = None,
+        created_at: datetime | None = None,
+        run_id: str | None = None,
+    ) -> "EvalReport":
+        cfg = dict(config or {})
+        models = ReportModels.from_config(cfg)
+        verifier_enabled = bool((cfg.get("verifier") or {}).get("enabled", True))
+        per_video = tuple(
+            PerVideoReport.from_run_score(path, score)
+            for path, score in sorted(result.per_video, key=lambda item: str(item[0]))
+        )
+        return cls(
+            schema_version=SCHEMA_VERSION,
+            run=ReportRun.build(
+                dataset=dataset,
+                policy_path=policy_path,
+                config_path=config_path,
+                models=models,
+                verifier_enabled=verifier_enabled,
+                created_at=created_at,
+                run_id=run_id,
+            ),
+            models=models,
+            metrics=ReportMetrics.from_run_score(result.aggregate),
+            latency=ReportLatency(),
+            runtime=ReportRuntime.current(),
+            quality_signals=ReportQualitySignals.from_run_score(result.aggregate),
+            per_video=per_video,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "EvalReport":
+        return cls(
+            schema_version=str(data.get("schema_version", SCHEMA_VERSION)),
+            run=ReportRun.from_dict(data.get("run", {})),
+            models=ReportModels.from_dict(data.get("models", {})),
+            metrics=ReportMetrics.from_dict(data.get("metrics", {})),
+            latency=ReportLatency.from_dict(data.get("latency", {})),
+            runtime=ReportRuntime.from_dict(data.get("runtime", {})),
+            quality_signals=ReportQualitySignals.from_dict(data.get("quality_signals", {})),
+            per_video=tuple(
+                PerVideoReport.from_dict(item)
+                for item in data.get("per_video", [])
+            ),
+        )
+
+    @classmethod
+    def load(cls, path: str | Path) -> "EvalReport":
+        return cls.from_dict(json.loads(Path(path).read_text(encoding="utf-8")))
+
+    def to_dict(self) -> dict:
+        return {
+            "schema_version": self.schema_version,
+            "run": self.run.to_dict(),
+            "models": self.models.to_dict(),
+            "metrics": self.metrics.to_dict(),
+            "latency": self.latency.to_dict(),
+            "runtime": self.runtime.to_dict(),
+            "quality_signals": self.quality_signals.to_dict(),
+            "per_video": [entry.to_dict() for entry in self.per_video],
+        }
+
+    def to_json(self, *, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent) + "\n"
+
+    def write(self, path: str | Path) -> None:
+        Path(path).write_text(self.to_json(), encoding="utf-8")


### PR DESCRIPTION
## Summary

- Adds `vrs/eval/report.py` with a versioned `EvalReport` dataclass (`schema_version: vrs.eval.report.v1`) plus typed sub-models for `run`, `models`, `metrics`, `latency`, `runtime`, `quality_signals`, and `per_video`. Round-trip via `to_dict` / `from_dict`; deterministic per-class ordering; metric floats rounded to 4 decimals.
- Wires `scripts/eval.py` to emit the new `report.json` from the existing `HarnessResult` + loaded YAML config — no changes to scoring semantics.
- Updates `vrs/eval/ci.py` to read both the legacy `aggregate.*` shape and the new `metrics` / `quality_signals` sections so committed baselines keep working through the schema transition.

## Notes

- `run.created_at` and `runtime.*` are diagnostic only. The regression gate compares `metrics` and `quality_signals`, so committed baselines are immune to clock and Python-version drift — called out in the README.
- Verifier model name is read from `verifier.model_id` and slugged into `run.run_id`. When `verifier.enabled: false`, `models.verifier` becomes `null` and `run.mode` flips to `detector_only`, so the same schema covers both eval modes without a v2 bump.
- Non-goals from the issue are respected: no D-Fire/Le2i adapters, no `CosmosBackend` rename, no detector/verifier behavior changes, no Prometheus metrics.

## Test plan

- [ ] `python -m pytest -q` — 29 new tests in `tests/test_eval.py` (round-trip stability, run-id slug, gate legacy-vs-v1 compatibility); full suite stays green
- [ ] `python -m vrs.eval.ci --baseline <legacy_aggregate>.json --current <schema_v1>.json` — gate reads both shapes
- [ ] Spot-check a generated `report.json` against the proposed shape in the issue

Closes #1