### PR TITLE
feat(eval): add detector-only mode

### DIFF
--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -20,21 +20,24 @@ import argparse
 import logging
 from pathlib import Path
 
-import yaml
-
 from vrs import setup_logging
-from vrs.eval import EvalReport, evaluate
+from vrs.eval import EvalReport, config_for_eval_mode, evaluate
 from vrs.eval.datasets import LabeledDirDataset
 
 logger = logging.getLogger(__name__)
 
 
-def main() -> None:
-    setup_logging()
+def build_arg_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(description="VRS — evaluate the cascade on a labeled dataset")
     ap.add_argument("--dataset", required=True, help="labeled dataset root (see LabeledDirDataset)")
     ap.add_argument("--config", default="configs/default.yaml")
     ap.add_argument("--policy", default="configs/policies/safety.yaml")
+    ap.add_argument(
+        "--mode",
+        choices=("full_cascade", "detector_only"),
+        default="full_cascade",
+        help="evaluation mode: full cascade with verifier, or detector/event-state only",
+    )
     ap.add_argument("--out", default="runs/eval")
     ap.add_argument(
         "--tolerance-s",
@@ -43,15 +46,27 @@ def main() -> None:
         help="temporal slack around GT event windows when matching alerts",
     )
     ap.add_argument("--report", default=None, help="JSON report path (default: <out>/report.json)")
-    args = ap.parse_args()
+    return ap
+
+
+def main(argv: list[str] | None = None) -> None:
+    setup_logging()
+    args = build_arg_parser().parse_args(argv)
 
     # Imported lazily so `uv run scripts/eval.py --help` works without cv2/torch.
-    from vrs.pipeline import build_pipeline
+    from vrs.pipeline import VRSPipeline, load_config
+    from vrs.policy import load_watch_policy
 
     dataset = LabeledDirDataset(args.dataset)
+    verifier_enabled = False if args.mode == "detector_only" else None
+    config = config_for_eval_mode(
+        load_config(args.config, verifier_enabled=verifier_enabled),
+        args.mode,
+    )
+    policy = load_watch_policy(args.policy)
 
     def _factory(video_out: Path):
-        return build_pipeline(args.config, args.policy, video_out)
+        return VRSPipeline(config, policy, video_out)
 
     result = evaluate(
         dataset=dataset,
@@ -62,8 +77,6 @@ def main() -> None:
 
     report_path = Path(args.report) if args.report else Path(args.out) / "report.json"
     report_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(args.config, encoding="utf-8") as f:
-        config = yaml.safe_load(f) or {}
     report = EvalReport.from_harness_result(
         result,
         dataset=args.dataset,

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -14,6 +14,7 @@ from vrs.eval import (
     EvalReport,
     GroundTruthEvent,
     HarnessResult,
+    config_for_eval_mode,
     score_alerts_against_truth,
 )
 from vrs.eval.datasets import LabeledDirDataset
@@ -304,6 +305,105 @@ def test_eval_report_round_trip_is_stable():
     assert list(payload["metrics"]["per_class"].keys()) == ["fire", "smoke"]
     assert EvalReport.from_dict(payload) == report
     assert json.loads(report.to_json()) == payload
+
+
+def test_config_for_eval_mode_marks_detector_only_without_mutating_source():
+    config = {
+        "detector": {"backend": "ultralytics", "model": "yoloe-11l-seg.pt"},
+        "verifier": {
+            "enabled": True,
+            "backend": "transformers",
+            "model_id": "nvidia/Cosmos-Reason2-2B",
+        },
+    }
+
+    effective = config_for_eval_mode(config, "detector_only")
+
+    assert config["verifier"]["enabled"] is True
+    assert effective["verifier"]["enabled"] is False
+
+    report = EvalReport.from_harness_result(
+        HarnessResult(aggregate=score_alerts_against_truth([], [])),
+        dataset="fixtures/mini-dataset",
+        config_path="configs/default.yaml",
+        policy_path="configs/policies/safety.yaml",
+        config=effective,
+        created_at=datetime(2026, 4, 26, 0, 0, tzinfo=UTC),
+    )
+    assert report.run.mode == "detector_only"
+    assert report.models.detector is not None
+    assert report.models.verifier is None
+
+
+def test_eval_cli_accepts_detector_only_mode():
+    from scripts.eval import build_arg_parser
+
+    args = build_arg_parser().parse_args(
+        [
+            "--dataset",
+            "fixtures/mini-dataset",
+            "--config",
+            "configs/default.yaml",
+            "--policy",
+            "configs/policies/safety.yaml",
+            "--mode",
+            "detector_only",
+            "--out",
+            "runs/eval-detector",
+        ]
+    )
+    assert args.mode == "detector_only"
+
+
+def test_detector_only_pipeline_construction_skips_verifier(monkeypatch, tmp_path: Path):
+    from vrs.pipeline import VRSPipeline
+    from vrs.policy.watch_policy import WatchItem, WatchPolicy
+
+    class _FakeDetector:
+        def __call__(self, frame):
+            return []
+
+        def batch(self, frames):
+            return [[] for _ in frames]
+
+    def fail_build_cosmos_backend(*args, **kwargs):
+        raise AssertionError("detector-only eval must not construct a VLM backend")
+
+    monkeypatch.setattr("vrs.pipeline.build_detector", lambda *args, **kwargs: _FakeDetector())
+    monkeypatch.setattr("vrs.pipeline.build_cosmos_backend", fail_build_cosmos_backend)
+
+    policy = WatchPolicy(
+        [
+            WatchItem(
+                name="fire",
+                detector_prompts=["fire"],
+                verifier_prompt="open flames",
+                severity="critical",
+                min_score=0.30,
+                min_persist_frames=1,
+            )
+        ]
+    )
+    config = config_for_eval_mode(
+        {
+            "ingest": {"target_fps": 4},
+            "detector": {"backend": "ultralytics", "model": "fake.pt"},
+            "event_state": {"window": 2},
+            "tracker": {"backend": "none"},
+            "verifier": {
+                "enabled": True,
+                "backend": "transformers",
+                "model_id": "nvidia/Cosmos-Reason2-2B",
+            },
+            "sink": {"write_thumbnails": False, "write_annotated": False},
+            "calibration": {"enabled": False},
+        },
+        "detector_only",
+    )
+
+    pipeline = VRSPipeline(config, policy, tmp_path)
+
+    assert pipeline.verifier is None
 
 
 def _report(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from vrs.pipeline import _validate_config
+from vrs.pipeline import _validate_config, load_config
 from vrs.policy.watch_policy import WatchPolicy, load_watch_policy
 from vrs.schemas import CandidateAlert, Detection, Frame, VerifiedAlert
 from vrs.triage.event_state import EventStateQueue
@@ -61,6 +61,26 @@ def test_validate_config_skips_model_id_when_verifier_disabled():
         "sink": {},
     }
     _validate_config(cfg, "test.yaml")  # should not raise
+
+
+def test_load_config_can_disable_verifier_before_validation(tmp_path: Path):
+    cfg = tmp_path / "detector-only.yaml"
+    cfg.write_text(
+        "ingest:\n"
+        "  target_fps: 4\n"
+        "detector:\n"
+        "  model: fake.pt\n"
+        "event_state:\n"
+        "  window: 2\n"
+        "verifier:\n"
+        "  enabled: true\n"
+        "sink: {}\n",
+        encoding="utf-8",
+    )
+
+    loaded = load_config(cfg, verifier_enabled=False)
+
+    assert loaded["verifier"]["enabled"] is False
 
 
 # ─── policy ────────────────────────────────────────────────────────────

--- a/vrs/eval/__init__.py
+++ b/vrs/eval/__init__.py
@@ -19,7 +19,7 @@ Upcoming:
 
 from __future__ import annotations
 
-from .harness import HarnessResult, evaluate
+from .harness import EvalMode, HarnessResult, config_for_eval_mode, evaluate
 from .metrics import aggregate_scores, score_alerts_against_truth
 from .report import (
     SCHEMA_VERSION,
@@ -45,6 +45,7 @@ __all__ = [
     "SCHEMA_VERSION",
     "ClassMetrics",
     "EvalItem",
+    "EvalMode",
     "EvalReport",
     "GroundTruthEvent",
     "HarnessResult",
@@ -59,6 +60,7 @@ __all__ = [
     "ReportRuntime",
     "RunScore",
     "aggregate_scores",
+    "config_for_eval_mode",
     "evaluate",
     "score_alerts_against_truth",
 ]

--- a/vrs/eval/harness.py
+++ b/vrs/eval/harness.py
@@ -16,9 +16,10 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Callable, Iterable
+from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from .datasets.base import Dataset
 from .metrics import aggregate_scores, score_alerts_against_truth
@@ -28,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 PipelineFactory = Callable[[Path], Any]  # (out_dir) -> something with .run(source)
+EvalMode = Literal["full_cascade", "detector_only"]
 
 
 @dataclass
@@ -40,6 +42,18 @@ class HarnessResult:
             "aggregate": self.aggregate.to_dict(),
             "per_video": [{"video": str(p), "score": s.to_dict()} for p, s in self.per_video],
         }
+
+
+def config_for_eval_mode(config: dict[str, Any], mode: EvalMode) -> dict[str, Any]:
+    """Return a copy of ``config`` adjusted for the requested eval mode."""
+    if mode not in ("full_cascade", "detector_only"):
+        raise ValueError(f"unknown eval mode: {mode!r}")
+
+    cfg = deepcopy(config)
+    if mode == "detector_only":
+        verifier = cfg.setdefault("verifier", {})
+        verifier["enabled"] = False
+    return cfg
 
 
 def evaluate(

--- a/vrs/pipeline.py
+++ b/vrs/pipeline.py
@@ -43,9 +43,14 @@ def _validate_config(cfg: dict, path: str = "<config>") -> None:
         _require_key(cfg, "verifier", "model_id", path)
 
 
-def load_config(path: str | Path) -> dict[str, Any]:
+def load_config(path: str | Path, *, verifier_enabled: bool | None = None) -> dict[str, Any]:
     with open(path, encoding="utf-8") as f:
         cfg = yaml.safe_load(f)
+    if verifier_enabled is not None:
+        cfg = dict(cfg or {})
+        verifier = dict(cfg.get("verifier") or {})
+        verifier["enabled"] = verifier_enabled
+        cfg["verifier"] = verifier
     _validate_config(cfg or {}, str(path))
     return cfg
 


### PR DESCRIPTION
## Summary
- add an eval mode switch with detector_only support
- run detector-only eval through the existing pipeline with verifier disabled in the effective config
- keep report.json on the stable schema with detector_only mode and no verifier model
- add CPU-only tests covering CLI parsing, report mode, and verifier construction guard

Closes #2

## Tests
- uv run ruff check scripts/eval.py vrs/eval/harness.py vrs/eval/__init__.py tests/test_eval.py
- uv run python -m pytest -q