### PR TITLE
[codex] ci(eval): add baseline regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,13 @@ jobs:
       - name: Run unit tests
         run: uv run python -m pytest -q
 
+      - name: Validate eval regression gate
+        run: |
+          uv run python -m vrs.eval.ci \
+            --baseline baselines/eval/report.json \
+            --current baselines/eval/report.json \
+            --max-f1-drop 0.02
+
   pr-integration:
     name: PR integration smoke test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -331,3 +331,19 @@ path. A future detector-only scoring mode can reuse the same report schema with
 machines and are not part of the regression contract. The CI gate
 (`uv run python -m vrs.eval.ci`) only compares `metrics` and `quality_signals`, so
 committed baselines are immune to clock and Python-version drift.
+
+The committed mini baseline lives at `baselines/eval/report.json`. Regenerate it
+only after an intentional fixture or metric-contract update:
+
+```bash
+uv run python scripts/write_eval_baseline.py --out baselines/eval/report.json
+```
+
+Compare a candidate report against the baseline with:
+
+```bash
+uv run python -m vrs.eval.ci \
+  --baseline baselines/eval/report.json \
+  --current runs/eval/report.json \
+  --max-f1-drop 0.02
+```

--- a/baselines/eval/README.md
+++ b/baselines/eval/README.md
@@ -1,0 +1,27 @@
+# Eval Baseline
+
+`report.json` is the committed mini evaluation baseline used by
+`python -m vrs.eval.ci`. It is generated from a deterministic synthetic scoring
+fixture, so it does not require GPU inference, model downloads, video files, or
+large datasets.
+
+Regenerate it after an intentional metric-contract or fixture update:
+
+```bash
+uv run python scripts/write_eval_baseline.py --out baselines/eval/report.json
+```
+
+Then run the regression gate against a candidate report:
+
+```bash
+uv run python -m vrs.eval.ci \
+  --baseline baselines/eval/report.json \
+  --current runs/eval/report.json \
+  --max-f1-drop 0.02
+```
+
+Exit codes are:
+
+- `0`: overall and per-class F1 are within tolerance.
+- `1`: at least one overall or per-class F1 regression exceeded tolerance.
+- `2`: a structural error prevented comparison.

--- a/baselines/eval/report.json
+++ b/baselines/eval/report.json
@@ -1,0 +1,144 @@
+{
+  "schema_version": "vrs.eval.report.v1",
+  "run": {
+    "run_id": "2026-04-26-mini-eval-fixture-yoloe-11l-seg-cosmos-reason2-2b",
+    "created_at": "2026-04-26T00:00:00Z",
+    "dataset": "mini-eval-fixture",
+    "mode": "full_cascade",
+    "policy_path": "configs/policies/safety.yaml",
+    "config_path": "configs/default.yaml"
+  },
+  "models": {
+    "detector": {
+      "backend": "ultralytics",
+      "model": "yoloe-11l-seg.pt"
+    },
+    "verifier": {
+      "backend": "transformers",
+      "model": "nvidia/Cosmos-Reason2-2B"
+    }
+  },
+  "metrics": {
+    "overall": {
+      "precision": 0.7143,
+      "recall": 0.8333,
+      "f1": 0.7692,
+      "tp": 5,
+      "fp": 2,
+      "fn": 1
+    },
+    "per_class": {
+      "fire": {
+        "precision": 0.75,
+        "recall": 0.75,
+        "f1": 0.75,
+        "tp": 3,
+        "fp": 1,
+        "fn": 1
+      },
+      "smoke": {
+        "precision": 0.6667,
+        "recall": 1.0,
+        "f1": 0.8,
+        "tp": 2,
+        "fp": 1,
+        "fn": 0
+      }
+    }
+  },
+  "latency": {
+    "detector_p50_ms": null,
+    "detector_p95_ms": null,
+    "verifier_p50_ms": null,
+    "verifier_p95_ms": null
+  },
+  "runtime": {
+    "python": null,
+    "torch": null,
+    "cuda": null,
+    "gpu_name": null,
+    "peak_vram_mb": null
+  },
+  "quality_signals": {
+    "verifier_flip_rate": 0.125,
+    "false_negative_flag_rate": 0.125,
+    "malformed_json_rate": null,
+    "queue_drops": null
+  },
+  "per_video": [
+    {
+      "video": "mini-fire-smoke-001.mp4",
+      "metrics": {
+        "overall": {
+          "precision": 0.75,
+          "recall": 1.0,
+          "f1": 0.8571,
+          "tp": 3,
+          "fp": 1,
+          "fn": 0
+        },
+        "per_class": {
+          "fire": {
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0,
+            "tp": 2,
+            "fp": 0,
+            "fn": 0
+          },
+          "smoke": {
+            "precision": 0.5,
+            "recall": 1.0,
+            "f1": 0.6667,
+            "tp": 1,
+            "fp": 1,
+            "fn": 0
+          }
+        }
+      },
+      "quality_signals": {
+        "verifier_flip_rate": 0.25,
+        "false_negative_flag_rate": 0.0,
+        "malformed_json_rate": null,
+        "queue_drops": null
+      }
+    },
+    {
+      "video": "mini-fire-smoke-002.mp4",
+      "metrics": {
+        "overall": {
+          "precision": 0.6667,
+          "recall": 0.6667,
+          "f1": 0.6667,
+          "tp": 2,
+          "fp": 1,
+          "fn": 1
+        },
+        "per_class": {
+          "fire": {
+            "precision": 0.5,
+            "recall": 0.5,
+            "f1": 0.5,
+            "tp": 1,
+            "fp": 1,
+            "fn": 1
+          },
+          "smoke": {
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0,
+            "tp": 1,
+            "fp": 0,
+            "fn": 0
+          }
+        }
+      },
+      "quality_signals": {
+        "verifier_flip_rate": 0.0,
+        "false_negative_flag_rate": 0.25,
+        "malformed_json_rate": null,
+        "queue_drops": null
+      }
+    }
+  ]
+}

--- a/scripts/write_eval_baseline.py
+++ b/scripts/write_eval_baseline.py
@@ -1,0 +1,107 @@
+"""Write the committed mini eval baseline report.
+
+This is intentionally synthetic: it exercises the stable report schema and CI
+regression gate without requiring GPU inference, model downloads, or video
+artifacts in the repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+
+from vrs.eval import (
+    EvalReport,
+    HarnessResult,
+    ReportRuntime,
+    RunScore,
+)
+from vrs.eval.schemas import ClassMetrics
+
+
+def _score(
+    *,
+    fire: ClassMetrics,
+    smoke: ClassMetrics,
+    n_alerts_total: int,
+    n_alerts_true: int,
+    n_fn_flagged: int,
+    n_events: int,
+) -> RunScore:
+    return RunScore(
+        per_class={"fire": fire, "smoke": smoke},
+        n_alerts_total=n_alerts_total,
+        n_alerts_true=n_alerts_true,
+        n_fn_flagged=n_fn_flagged,
+        n_events=n_events,
+    )
+
+
+def build_baseline_report() -> EvalReport:
+    """Build the deterministic report used by ``baselines/eval/report.json``."""
+    aggregate = _score(
+        fire=ClassMetrics(tp=3, fp=1, fn=1),
+        smoke=ClassMetrics(tp=2, fp=1, fn=0),
+        n_alerts_total=8,
+        n_alerts_true=7,
+        n_fn_flagged=1,
+        n_events=6,
+    )
+    per_video = [
+        (
+            Path("mini-fire-smoke-001.mp4"),
+            _score(
+                fire=ClassMetrics(tp=2, fp=0, fn=0),
+                smoke=ClassMetrics(tp=1, fp=1, fn=0),
+                n_alerts_total=4,
+                n_alerts_true=3,
+                n_fn_flagged=0,
+                n_events=3,
+            ),
+        ),
+        (
+            Path("mini-fire-smoke-002.mp4"),
+            _score(
+                fire=ClassMetrics(tp=1, fp=1, fn=1),
+                smoke=ClassMetrics(tp=1, fp=0, fn=0),
+                n_alerts_total=4,
+                n_alerts_true=4,
+                n_fn_flagged=1,
+                n_events=3,
+            ),
+        ),
+    ]
+    report = EvalReport.from_harness_result(
+        HarnessResult(aggregate=aggregate, per_video=per_video),
+        dataset="mini-eval-fixture",
+        config_path="configs/default.yaml",
+        policy_path="configs/policies/safety.yaml",
+        config={
+            "detector": {"backend": "ultralytics", "model": "yoloe-11l-seg.pt"},
+            "verifier": {
+                "enabled": True,
+                "backend": "transformers",
+                "model_id": "nvidia/Cosmos-Reason2-2B",
+            },
+        },
+        created_at=datetime(2026, 4, 26, 0, 0, tzinfo=UTC),
+        run_id="2026-04-26-mini-eval-fixture-yoloe-11l-seg-cosmos-reason2-2b",
+    )
+    return replace(report, runtime=ReportRuntime())
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Write the committed mini eval baseline")
+    parser.add_argument("--out", default="baselines/eval/report.json")
+    args = parser.parse_args(argv)
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    build_baseline_report().write(out)
+    print(f"Wrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -570,6 +570,34 @@ def test_gate_reads_schema_v1_reports():
     assert result.current_flip_rate == pytest.approx(0.12)
 
 
+def test_committed_eval_baseline_matches_regeneration_script():
+    from scripts.write_eval_baseline import build_baseline_report
+
+    baseline_path = Path("baselines/eval/report.json")
+    committed = json.loads(baseline_path.read_text(encoding="utf-8"))
+    regenerated = build_baseline_report().to_dict()
+
+    assert committed == regenerated
+
+
+def test_gate_accepts_committed_eval_baseline():
+    from vrs.eval.ci import compare_reports
+
+    baseline = json.loads(Path("baselines/eval/report.json").read_text(encoding="utf-8"))
+    current = _schema_v1_report(
+        {"fire": 0.74, "smoke": 0.79},
+        overall_f1=0.76,
+        flip_rate=0.125,
+        fn_flag_rate=0.125,
+    )
+
+    result = compare_reports(baseline, current, max_f1_drop=0.02)
+
+    assert result.passed is True
+    assert result.overall.regressed is False
+    assert {d.class_name for d in result.per_class} == {"fire", "smoke"}
+
+
 def test_gate_supports_legacy_vs_schema_v1_reports():
     from vrs.eval.ci import compare_reports
 
@@ -613,6 +641,17 @@ def test_gate_rejects_malformed_report():
         compare_reports({}, _report({"fire": 0.8}))
 
 
+def test_gate_rejects_structural_metric_errors():
+    from vrs.eval.ci import compare_reports
+
+    baseline = _schema_v1_report({"fire": 0.80}, overall_f1=0.80)
+    current = _schema_v1_report({"fire": 0.79}, overall_f1=0.79)
+    del current["metrics"]["per_class"]["fire"]["f1"]
+
+    with pytest.raises(ValueError, match=r"metrics\.per_class\.fire\.f1"):
+        compare_reports(baseline, current)
+
+
 def test_gate_cli_exit_codes(tmp_path: Path):
     import json as _json
 
@@ -621,13 +660,16 @@ def test_gate_cli_exit_codes(tmp_path: Path):
     baseline = tmp_path / "baseline.json"
     current_pass = tmp_path / "current_pass.json"
     current_fail = tmp_path / "current_fail.json"
+    current_invalid = tmp_path / "current_invalid.json"
 
     baseline.write_text(_json.dumps(_report({"fire": 0.80}, overall_f1=0.80)))
     current_pass.write_text(_json.dumps(_report({"fire": 0.79}, overall_f1=0.79)))
     current_fail.write_text(_json.dumps(_report({"fire": 0.50}, overall_f1=0.50)))
+    current_invalid.write_text(_json.dumps({"metrics": {"per_class": {"fire": {}}}}))
 
     assert ci_main(["--baseline", str(baseline), "--current", str(current_pass)]) == 0
     assert ci_main(["--baseline", str(baseline), "--current", str(current_fail)]) == 1
+    assert ci_main(["--baseline", str(baseline), "--current", str(current_invalid)]) == 2
     assert (
         ci_main(["--baseline", str(baseline), "--current", str(tmp_path / "nonexistent.json")]) == 2
     )

--- a/vrs/eval/ci.py
+++ b/vrs/eval/ci.py
@@ -26,6 +26,13 @@ import sys
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
+
+from .report import SCHEMA_VERSION
+
+
+class ReportStructureError(ValueError):
+    """Raised when an eval report does not match the supported metric shape."""
 
 
 @dataclass
@@ -95,29 +102,49 @@ class GateResult:
 # ──────────────────────────────────────────────────────────────────────
 
 
-def _metrics_section(report: Mapping[str, object]) -> Mapping[str, object]:
-    if isinstance(report.get("metrics"), Mapping):
-        return report["metrics"]
-    if isinstance(report.get("aggregate"), Mapping):
-        return report["aggregate"]
+def _as_mapping(value: Any, path: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ReportStructureError(f"expected object at '{path}'")
+    return value
+
+
+def _read_f1(value: Any, path: str) -> float:
+    metrics = _as_mapping(value, path)
+    if "f1" not in metrics:
+        raise ReportStructureError(f"missing required field '{path}.f1'")
+    try:
+        return float(metrics["f1"])
+    except (TypeError, ValueError) as exc:
+        raise ReportStructureError(f"expected numeric field '{path}.f1'") from exc
+
+
+def _metrics_section(report: Mapping[str, Any]) -> Mapping[str, Any]:
+    if report.get("schema_version") not in (None, SCHEMA_VERSION):
+        raise ReportStructureError(
+            f"unsupported schema_version {report.get('schema_version')!r}; expected {SCHEMA_VERSION!r}"
+        )
+    if "metrics" in report:
+        return _as_mapping(report.get("metrics"), "metrics")
+    if "aggregate" in report:
+        return _as_mapping(report.get("aggregate"), "aggregate")
+    raise ReportStructureError("missing required top-level 'metrics' section")
+
+
+def _quality_signals_section(report: Mapping[str, Any]) -> Mapping[str, Any]:
+    if "quality_signals" in report:
+        return _as_mapping(report.get("quality_signals"), "quality_signals")
+    if "aggregate" in report:
+        return _as_mapping(report.get("aggregate"), "aggregate")
     return {}
 
 
-def _quality_signals_section(report: Mapping[str, object]) -> Mapping[str, object]:
-    if isinstance(report.get("quality_signals"), Mapping):
-        return report["quality_signals"]
-    if isinstance(report.get("aggregate"), Mapping):
-        return report["aggregate"]
-    return {}
+def _per_class_f1(report: Mapping[str, Any]) -> dict[str, float]:
+    per = _as_mapping(_metrics_section(report).get("per_class"), "metrics.per_class")
+    return {str(cls): _read_f1(metrics, f"metrics.per_class.{cls}") for cls, metrics in per.items()}
 
 
-def _per_class_f1(report: dict) -> dict[str, float]:
-    per = _metrics_section(report).get("per_class", {})
-    return {cls: float(m.get("f1", 0.0)) for cls, m in per.items()}
-
-
-def _overall_f1(report: dict) -> float:
-    return float(_metrics_section(report).get("overall", {}).get("f1", 0.0))
+def _overall_f1(report: Mapping[str, Any]) -> float:
+    return _read_f1(_metrics_section(report).get("overall"), "metrics.overall")
 
 
 def compare_reports(


### PR DESCRIPTION
Adds a committed mini eval baseline report, a deterministic regeneration script, stricter structural validation in `vrs.eval.ci`, and CI/tests for pass, regression, and invalid-report cases.

Validation:
- `uv run python -m pytest -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m vrs.eval.ci --baseline baselines/eval/report.json --current baselines/eval/report.json --max-f1-drop 0.02`