### PR TITLE
[codex] feat(eval): add D-Fire dataset adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ Outputs:
    Drop the clips into a directory, add them to `configs/multistream.yaml`
    as `file://` sources, and re-run `uv run scripts/bench.py`.
 
+   For D-Fire detector-only evaluation, see [docs/dfire-dataset.md](docs/dfire-dataset.md).
+
 ## Watch Policy — the only place you maintain
 
 ```yaml

--- a/docs/dfire-dataset.md
+++ b/docs/dfire-dataset.md
@@ -1,0 +1,66 @@
+# D-Fire Evaluation Dataset
+
+D-Fire is a public image dataset for fire and smoke detection. Its labels use
+YOLO rows with normalized coordinates:
+
+```text
+<class_id> <center_x> <center_y> <width> <height>
+```
+
+The adapter converts those YOLO boxes to VRS alert-box coordinates:
+`x_min, y_min, width, height`, still normalized to `0..1`.
+
+Use a small local subset for VRS evaluation. Do not commit the full dataset.
+
+## Layout
+
+```text
+datasets/dfire-mini/
+  images/
+    sample-001.jpg
+    sample-002.jpg
+  labels/
+    sample-001.txt
+    sample-002.txt
+```
+
+Images with an empty or missing label file are treated as quiet samples. Set
+`require_labels=True` when constructing `DFireDataset` if every image must have
+an explicit label file.
+
+## Class Map
+
+The built-in adapter uses the common D-Fire YOLO mapping:
+
+```text
+0 smoke
+1 fire
+```
+
+Pass a custom `class_map` to `DFireDataset` if your downloaded split uses a
+different class order.
+
+## Run Detector-Only Eval
+
+```bash
+python scripts/eval.py \
+  --dataset datasets/dfire-mini \
+  --dataset-format dfire \
+  --config configs/default.yaml \
+  --policy configs/policies/safety.yaml \
+  --mode detector_only \
+  --out runs/eval-dfire
+```
+
+By default, scoring is image-level class presence: a fire alert at `0.0s`
+matches a fire label in the image. To require box localization, pass an IoU
+threshold:
+
+```bash
+python scripts/eval.py \
+  --dataset datasets/dfire-mini \
+  --dataset-format dfire \
+  --mode detector_only \
+  --bbox-iou-threshold 0.5 \
+  --out runs/eval-dfire-bbox
+```

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -9,9 +9,10 @@ Example:
         --tolerance-s  1.0
 
 Layout of the dataset directory — see vrs.eval.datasets.labeled_dir for the
-sidecar-JSON schema. Each video gets its own subdir under ``--out`` holding
-its ``alerts.jsonl`` and event thumbnails. A single versioned ``report.json``
-lands at ``--out`` (or the path given via ``--report``).
+sidecar-JSON schema, or pass ``--dataset-format dfire`` for a D-Fire
+``images/`` + ``labels/`` tree. Each media item gets its own subdir under
+``--out`` holding its ``alerts.jsonl`` and event thumbnails. A single versioned
+``report.json`` lands at ``--out`` (or the path given via ``--report``).
 """
 
 from __future__ import annotations
@@ -22,14 +23,20 @@ from pathlib import Path
 
 from vrs import setup_logging
 from vrs.eval import EvalReport, config_for_eval_mode, evaluate
-from vrs.eval.datasets import LabeledDirDataset
+from vrs.eval.datasets import DATASET_ADAPTERS, build_dataset
 
 logger = logging.getLogger(__name__)
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(description="VRS — evaluate the cascade on a labeled dataset")
-    ap.add_argument("--dataset", required=True, help="labeled dataset root (see LabeledDirDataset)")
+    ap.add_argument("--dataset", required=True, help="dataset root")
+    ap.add_argument(
+        "--dataset-format",
+        choices=tuple(sorted(DATASET_ADAPTERS)),
+        default="labeled_dir",
+        help="dataset adapter to use",
+    )
     ap.add_argument("--config", default="configs/default.yaml")
     ap.add_argument("--policy", default="configs/policies/safety.yaml")
     ap.add_argument(
@@ -45,6 +52,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=1.0,
         help="temporal slack around GT event windows when matching alerts",
     )
+    ap.add_argument(
+        "--bbox-iou-threshold",
+        type=float,
+        default=None,
+        help="require bbox IoU at or above this threshold when GT boxes are present",
+    )
     ap.add_argument("--report", default=None, help="JSON report path (default: <out>/report.json)")
     return ap
 
@@ -57,7 +70,7 @@ def main(argv: list[str] | None = None) -> None:
     from vrs.pipeline import VRSPipeline, load_config
     from vrs.policy import load_watch_policy
 
-    dataset = LabeledDirDataset(args.dataset)
+    dataset = build_dataset(args.dataset_format, args.dataset)
     verifier_enabled = False if args.mode == "detector_only" else None
     config = config_for_eval_mode(
         load_config(args.config, verifier_enabled=verifier_enabled),
@@ -73,6 +86,7 @@ def main(argv: list[str] | None = None) -> None:
         pipeline_factory=_factory,
         out_dir=args.out,
         tolerance_s=args.tolerance_s,
+        bbox_iou_threshold=args.bbox_iou_threshold,
     )
 
     report_path = Path(args.report) if args.report else Path(args.out) / "report.json"

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -6,6 +6,8 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
+import cv2
+import numpy as np
 import pytest
 
 from vrs.eval import (
@@ -14,22 +16,32 @@ from vrs.eval import (
     EvalReport,
     GroundTruthEvent,
     HarnessResult,
+    bbox_iou_xywh_norm,
     config_for_eval_mode,
     score_alerts_against_truth,
 )
-from vrs.eval.datasets import LabeledDirDataset
+from vrs.eval.datasets import DFireDataset, LabeledDirDataset, build_dataset
 from vrs.eval.metrics import aggregate_scores
+from vrs.schemas import CandidateAlert, Detection, VerifiedAlert
 
 
 def _alert(
-    class_name: str, peak_pts_s: float, *, true_alert: bool = True, fn_cls: str | None = None
+    class_name: str,
+    peak_pts_s: float,
+    *,
+    true_alert: bool = True,
+    fn_cls: str | None = None,
+    bbox: tuple[float, float, float, float] | None = None,
 ) -> dict:
-    return {
+    out = {
         "class_name": class_name,
         "peak_pts_s": peak_pts_s,
         "true_alert": true_alert,
         "false_negative_class": fn_cls,
     }
+    if bbox is not None:
+        out["bbox_xywh_norm"] = bbox
+    return out
 
 
 def _event(cls: str, start: float, end: float) -> GroundTruthEvent:
@@ -142,6 +154,59 @@ def test_score_restricted_classes_excludes_others():
     assert score.n_events == 0
 
 
+def test_bbox_iou_xywh_norm_uses_vrs_coordinates():
+    assert bbox_iou_xywh_norm((0.5, 0.5, 0.2, 0.2), (0.5, 0.5, 0.2, 0.2)) == pytest.approx(
+        1.0
+    )
+    assert bbox_iou_xywh_norm((0.1, 0.1, 0.1, 0.1), (0.9, 0.9, 0.1, 0.1)) == 0.0
+
+
+def test_bbox_threshold_requires_matching_alert_box():
+    events = [
+        GroundTruthEvent(
+            class_name="fire",
+            start_s=0.0,
+            end_s=0.0,
+            bbox_xywh_norm=(0.5, 0.5, 0.2, 0.2),
+        )
+    ]
+    image_level = score_alerts_against_truth(
+        [_alert("fire", 0.0, bbox=(0.1, 0.1, 0.1, 0.1))],
+        events,
+        tolerance_s=0.0,
+    )
+    bbox_level = score_alerts_against_truth(
+        [_alert("fire", 0.0, bbox=(0.1, 0.1, 0.1, 0.1))],
+        events,
+        tolerance_s=0.0,
+        bbox_iou_threshold=0.5,
+    )
+    assert image_level.per_class["fire"].tp == 1
+    assert (bbox_level.per_class["fire"].tp, bbox_level.per_class["fire"].fn) == (0, 1)
+
+
+def test_detector_only_alert_serializes_peak_detector_bbox():
+    alert = VerifiedAlert(
+        candidate=CandidateAlert(
+            class_name="fire",
+            severity="critical",
+            start_pts_s=0.0,
+            peak_pts_s=0.0,
+            peak_frame_index=0,
+            peak_detections=[
+                Detection("fire", 0.9, (20.0, 10.0, 60.0, 50.0)),
+            ],
+            keyframes=[np.zeros((100, 200, 3), dtype=np.uint8)],
+        ),
+        true_alert=True,
+        confidence=1.0,
+        false_negative_class=None,
+        rationale="verifier disabled",
+    )
+
+    assert alert.to_json()["bbox_xywh_norm"] == pytest.approx([0.1, 0.1, 0.2, 0.4])
+
+
 # ─── aggregation ──────────────────────────────────────────────────────
 
 
@@ -183,6 +248,88 @@ def test_labeled_dir_yields_items_with_events(tmp_path: Path):
 def test_labeled_dir_rejects_nonexistent_root(tmp_path: Path):
     with pytest.raises(FileNotFoundError):
         LabeledDirDataset(tmp_path / "does-not-exist")
+
+
+# ─── DFireDataset ─────────────────────────────────────────────────────
+
+
+def _make_dfire_root(tmp_path: Path) -> Path:
+    root = tmp_path / "dfire-mini"
+    (root / "images").mkdir(parents=True)
+    (root / "labels").mkdir()
+    return root
+
+
+def test_dfire_yields_image_items_with_bbox_events(tmp_path: Path):
+    root = _make_dfire_root(tmp_path)
+    (root / "images" / "a.jpg").write_bytes(b"fake image bytes")
+    (root / "images" / "b.png").write_bytes(b"fake image bytes")
+    (root / "labels" / "a.txt").write_text(
+        "1 0.50 0.50 0.20 0.30\n0 0.25 0.25 0.10 0.10\n",
+        encoding="utf-8",
+    )
+    (root / "labels" / "b.txt").write_text("", encoding="utf-8")
+
+    items = list(DFireDataset(root))
+
+    assert [item.video_path.name for item in items] == ["a.jpg", "b.png"]
+    assert items[0].events == [
+        GroundTruthEvent("fire", 0.0, 0.0, (0.40, 0.35, 0.20, 0.30)),
+        GroundTruthEvent("smoke", 0.0, 0.0, (0.20, 0.20, 0.10, 0.10)),
+    ]
+    assert items[1].events == []
+
+
+def test_dfire_missing_label_file_is_quiet_by_default(tmp_path: Path):
+    root = _make_dfire_root(tmp_path)
+    (root / "images" / "quiet.jpg").write_bytes(b"fake image bytes")
+
+    [item] = list(DFireDataset(root))
+
+    assert item.video_path.name == "quiet.jpg"
+    assert item.events == []
+
+
+def test_dfire_can_require_label_files(tmp_path: Path):
+    root = _make_dfire_root(tmp_path)
+    (root / "images" / "quiet.jpg").write_bytes(b"fake image bytes")
+
+    with pytest.raises(FileNotFoundError):
+        list(DFireDataset(root, require_labels=True))
+
+
+def test_dfire_rejects_malformed_yolo_rows(tmp_path: Path):
+    root = _make_dfire_root(tmp_path)
+    (root / "images" / "bad.jpg").write_bytes(b"fake image bytes")
+    (root / "labels" / "bad.txt").write_text("1 0.5 0.5\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="expected 5 YOLO fields"):
+        list(DFireDataset(root))
+
+
+def test_dataset_registry_builds_dfire(tmp_path: Path):
+    root = _make_dfire_root(tmp_path)
+    (root / "images" / "a.jpg").write_bytes(b"fake image bytes")
+    (root / "labels" / "a.txt").write_text("", encoding="utf-8")
+
+    dataset = build_dataset("dfire", root)
+
+    assert isinstance(dataset, DFireDataset)
+
+
+def test_stream_reader_yields_single_frame_for_image(tmp_path: Path):
+    from vrs.ingest import StreamReader
+
+    image_path = tmp_path / "frame.jpg"
+    image = np.full((8, 12, 3), 127, dtype=np.uint8)
+    assert cv2.imwrite(str(image_path), image)
+
+    frames = list(StreamReader(str(image_path), target_fps=4))
+
+    assert len(frames) == 1
+    assert frames[0].index == 0
+    assert frames[0].pts_s == 0.0
+    assert frames[0].image.shape == (8, 12, 3)
 
 
 # ─── harness integration (stubbed pipeline) ────────────────────────────
@@ -342,6 +489,8 @@ def test_eval_cli_accepts_detector_only_mode():
         [
             "--dataset",
             "fixtures/mini-dataset",
+            "--dataset-format",
+            "dfire",
             "--config",
             "configs/default.yaml",
             "--policy",
@@ -350,9 +499,13 @@ def test_eval_cli_accepts_detector_only_mode():
             "detector_only",
             "--out",
             "runs/eval-detector",
+            "--bbox-iou-threshold",
+            "0.5",
         ]
     )
     assert args.mode == "detector_only"
+    assert args.dataset_format == "dfire"
+    assert args.bbox_iou_threshold == 0.5
 
 
 def test_detector_only_pipeline_construction_skips_verifier(monkeypatch, tmp_path: Path):

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -155,9 +155,7 @@ def test_score_restricted_classes_excludes_others():
 
 
 def test_bbox_iou_xywh_norm_uses_vrs_coordinates():
-    assert bbox_iou_xywh_norm((0.5, 0.5, 0.2, 0.2), (0.5, 0.5, 0.2, 0.2)) == pytest.approx(
-        1.0
-    )
+    assert bbox_iou_xywh_norm((0.5, 0.5, 0.2, 0.2), (0.5, 0.5, 0.2, 0.2)) == pytest.approx(1.0)
     assert bbox_iou_xywh_norm((0.1, 0.1, 0.1, 0.1), (0.9, 0.9, 0.1, 0.1)) == 0.0
 
 

--- a/vrs/eval/__init__.py
+++ b/vrs/eval/__init__.py
@@ -8,19 +8,19 @@ Current scope:
   * Per-class P/R/F1 + verifier-flip rate + FN-flag rate (``metrics``).
   * Stable, versioned ``EvalReport`` JSON contract (``report``).
   * Harness that iterates a dataset → runs the cascade → scores
-    (``harness``), with the labeled-directory adapter under ``datasets``.
+    (``harness``), with labeled-directory and D-Fire adapters under
+    ``datasets``.
   * Regression gate that compares two reports and exits non-zero on F1
     drops beyond a tolerance (``ci``, run as ``python -m vrs.eval.ci``).
 
 Upcoming:
-  * ``datasets/dfire.py`` and ``datasets/le2i.py`` — real public datasets.
-  * Detector-only evaluation mode reusing the same report schema.
+  * ``datasets/le2i.py`` — video-event public dataset coverage.
 """
 
 from __future__ import annotations
 
 from .harness import EvalMode, HarnessResult, config_for_eval_mode, evaluate
-from .metrics import aggregate_scores, score_alerts_against_truth
+from .metrics import aggregate_scores, bbox_iou_xywh_norm, score_alerts_against_truth
 from .report import (
     SCHEMA_VERSION,
     EvalReport,
@@ -60,6 +60,7 @@ __all__ = [
     "ReportRuntime",
     "RunScore",
     "aggregate_scores",
+    "bbox_iou_xywh_norm",
     "config_for_eval_mode",
     "evaluate",
     "score_alerts_against_truth",

--- a/vrs/eval/datasets/__init__.py
+++ b/vrs/eval/datasets/__init__.py
@@ -7,7 +7,26 @@ to change.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from .base import Dataset
+from .dfire import DFireDataset
 from .labeled_dir import LabeledDirDataset
 
-__all__ = ["Dataset", "LabeledDirDataset"]
+DATASET_ADAPTERS = {
+    "labeled_dir": LabeledDirDataset,
+    "dfire": DFireDataset,
+}
+
+
+def build_dataset(adapter: str, root: str | Path) -> Dataset:
+    try:
+        dataset_cls = DATASET_ADAPTERS[adapter]
+    except KeyError as exc:
+        raise ValueError(
+            f"unknown dataset adapter: {adapter!r}. Valid: {sorted(DATASET_ADAPTERS)}"
+        ) from exc
+    return dataset_cls(root)
+
+
+__all__ = ["DATASET_ADAPTERS", "DFireDataset", "Dataset", "LabeledDirDataset", "build_dataset"]

--- a/vrs/eval/datasets/dfire.py
+++ b/vrs/eval/datasets/dfire.py
@@ -68,7 +68,9 @@ class DFireDataset(Dataset):
             line = raw_line.strip()
             if not line:
                 continue
-            events.append(_parse_yolo_label(line, label=label, line_no=line_no, class_map=self.class_map))
+            events.append(
+                _parse_yolo_label(line, label=label, line_no=line_no, class_map=self.class_map)
+            )
         return events
 
 
@@ -110,12 +112,7 @@ def _parse_yolo_label(
 
 def _valid_yolo_bbox(bbox: tuple[float, ...]) -> bool:
     cx, cy, width, height = bbox
-    return (
-        0.0 <= cx <= 1.0
-        and 0.0 <= cy <= 1.0
-        and 0.0 < width <= 1.0
-        and 0.0 < height <= 1.0
-    )
+    return 0.0 <= cx <= 1.0 and 0.0 <= cy <= 1.0 and 0.0 < width <= 1.0 and 0.0 < height <= 1.0
 
 
 def _yolo_to_vrs_bbox(bbox: tuple[float, ...]) -> tuple[float, float, float, float]:

--- a/vrs/eval/datasets/dfire.py
+++ b/vrs/eval/datasets/dfire.py
@@ -1,0 +1,123 @@
+"""D-Fire dataset adapter.
+
+D-Fire is an image dataset with YOLO-format labels. The adapter exposes each
+image as one ``EvalItem`` and converts every label row to a zero-duration
+``GroundTruthEvent`` with an attached normalized bbox.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+
+from ..schemas import EvalItem, GroundTruthEvent
+from .base import Dataset
+
+DEFAULT_CLASS_MAP = {
+    0: "smoke",
+    1: "fire",
+}
+IMAGE_SUFFIXES = {".bmp", ".jpeg", ".jpg", ".png", ".webp"}
+
+
+class DFireDataset(Dataset):
+    """Load a D-Fire style ``images/`` + ``labels/`` tree.
+
+    Label files use YOLO rows:
+    ``<class_id> <center_x> <center_y> <width> <height>``.
+    Coordinates must already be normalized to ``0..1``. The adapter converts
+    them to VRS ``bbox_xywh_norm`` values: ``x_min, y_min, width, height``.
+    """
+
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        image_dir: str = "images",
+        label_dir: str = "labels",
+        class_map: Mapping[int, str] | None = None,
+        require_labels: bool = False,
+    ):
+        self.root = Path(root)
+        if not self.root.is_dir():
+            raise FileNotFoundError(f"{self.root} is not a directory")
+
+        self.image_root = self.root / image_dir
+        self.label_root = self.root / label_dir
+        if not self.image_root.is_dir():
+            raise FileNotFoundError(f"{self.image_root} is not a directory")
+        if not self.label_root.is_dir():
+            raise FileNotFoundError(f"{self.label_root} is not a directory")
+
+        self.class_map = dict(class_map or DEFAULT_CLASS_MAP)
+        self.require_labels = require_labels
+
+    def __iter__(self) -> Iterator[EvalItem]:
+        for image in _iter_images(self.image_root):
+            yield EvalItem(video_path=image, events=self._load_labels(image))
+
+    def _load_labels(self, image: Path) -> list[GroundTruthEvent]:
+        label = self.label_root / f"{image.stem}.txt"
+        if not label.exists():
+            if self.require_labels:
+                raise FileNotFoundError(f"missing D-Fire label file: {label}")
+            return []
+
+        events: list[GroundTruthEvent] = []
+        for line_no, raw_line in enumerate(label.read_text(encoding="utf-8").splitlines(), 1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            events.append(_parse_yolo_label(line, label=label, line_no=line_no, class_map=self.class_map))
+        return events
+
+
+def _iter_images(root: Path) -> Iterator[Path]:
+    for path in sorted(root.iterdir()):
+        if path.is_file() and path.suffix.lower() in IMAGE_SUFFIXES:
+            yield path
+
+
+def _parse_yolo_label(
+    line: str,
+    *,
+    label: Path,
+    line_no: int,
+    class_map: Mapping[int, str],
+) -> GroundTruthEvent:
+    parts = line.split()
+    if len(parts) != 5:
+        raise ValueError(f"{label}:{line_no}: expected 5 YOLO fields, got {len(parts)}")
+
+    try:
+        class_id = int(parts[0])
+        bbox = tuple(float(value) for value in parts[1:5])
+    except ValueError as exc:
+        raise ValueError(f"{label}:{line_no}: invalid YOLO label row: {line!r}") from exc
+
+    if class_id not in class_map:
+        raise ValueError(f"{label}:{line_no}: unknown D-Fire class id {class_id}")
+    if len(bbox) != 4 or not _valid_yolo_bbox(bbox):
+        raise ValueError(f"{label}:{line_no}: bbox values must be normalized YOLO coordinates")
+
+    return GroundTruthEvent(
+        class_name=class_map[class_id],
+        start_s=0.0,
+        end_s=0.0,
+        bbox_xywh_norm=_yolo_to_vrs_bbox(bbox),
+    )
+
+
+def _valid_yolo_bbox(bbox: tuple[float, ...]) -> bool:
+    cx, cy, width, height = bbox
+    return (
+        0.0 <= cx <= 1.0
+        and 0.0 <= cy <= 1.0
+        and 0.0 < width <= 1.0
+        and 0.0 < height <= 1.0
+    )
+
+
+def _yolo_to_vrs_bbox(bbox: tuple[float, ...]) -> tuple[float, float, float, float]:
+    cx, cy, width, height = bbox
+    return (cx - width / 2, cy - height / 2, width, height)

--- a/vrs/eval/harness.py
+++ b/vrs/eval/harness.py
@@ -62,6 +62,7 @@ def evaluate(
     out_dir: str | Path,
     *,
     tolerance_s: float = 1.0,
+    bbox_iou_threshold: float | None = None,
     alerts_filename: str = "alerts.jsonl",
     classes: Iterable[str] | None = None,
 ) -> HarnessResult:
@@ -99,6 +100,7 @@ def evaluate(
             alerts,
             item.events,
             tolerance_s=tolerance_s,
+            bbox_iou_threshold=bbox_iou_threshold,
             classes=classes_set,
         )
         per_video.append((item.video_path, score))

--- a/vrs/eval/metrics.py
+++ b/vrs/eval/metrics.py
@@ -27,6 +27,7 @@ def score_alerts_against_truth(
     events: Sequence[GroundTruthEvent],
     *,
     tolerance_s: float = 1.0,
+    bbox_iou_threshold: float | None = None,
     classes: Iterable[str] | None = None,
 ) -> RunScore:
     """Compute per-class P/R/F1 + flip/FN rates for one run's alerts.
@@ -39,11 +40,16 @@ def score_alerts_against_truth(
         tolerance_s: event windows are extended by this much on both sides
             before matching. Absorbs the ~cooldown-window jitter between the
             event's physical onset and when the cascade promotes it.
+        bbox_iou_threshold: when set, bbox-bearing events only match alerts
+            with ``bbox_xywh_norm`` at or above this IoU. Leave as ``None`` for
+            image/event-level scoring.
         classes: restrict scoring to these class names. Defaults to the union
             of classes that appear in alerts or events.
     """
     if tolerance_s < 0:
         raise ValueError("tolerance_s must be >= 0")
+    if bbox_iou_threshold is not None and not 0.0 <= bbox_iou_threshold <= 1.0:
+        raise ValueError("bbox_iou_threshold must be between 0 and 1")
 
     if classes is None:
         classes = {a["class_name"] for a in alerts} | {e.class_name for e in events}
@@ -75,9 +81,16 @@ def score_alerts_against_truth(
             for i, ev in enumerate(cls_events):
                 if matched[i]:
                     continue
-                if ev.start_s - tolerance_s <= pts <= ev.end_s + tolerance_s:
-                    hit_idx = i
-                    break
+                if not ev.start_s - tolerance_s <= pts <= ev.end_s + tolerance_s:
+                    continue
+                if bbox_iou_threshold is not None and not _bbox_matches(
+                    alert,
+                    ev,
+                    iou_threshold=bbox_iou_threshold,
+                ):
+                    continue
+                hit_idx = i
+                break
             if hit_idx is None:
                 cm.fp += 1
             else:
@@ -88,6 +101,41 @@ def score_alerts_against_truth(
         score.per_class[cls] = cm
 
     return score
+
+
+def _bbox_matches(alert: dict, event: GroundTruthEvent, *, iou_threshold: float) -> bool:
+    if event.bbox_xywh_norm is None:
+        return True
+    alert_bbox = alert.get("bbox_xywh_norm")
+    if alert_bbox is None:
+        return False
+    return bbox_iou_xywh_norm(alert_bbox, event.bbox_xywh_norm) >= iou_threshold
+
+
+def bbox_iou_xywh_norm(
+    a: Sequence[float],
+    b: Sequence[float],
+) -> float:
+    """IoU for normalized ``x_min, y_min, width, height`` boxes."""
+    if len(a) != 4 or len(b) != 4:
+        raise ValueError("bbox_xywh_norm values must contain exactly 4 numbers")
+
+    ax1, ay1, ax2, ay2 = _xywh_to_xyxy_corners(a)
+    bx1, by1, bx2, by2 = _xywh_to_xyxy_corners(b)
+
+    inter_w = max(0.0, min(ax2, bx2) - max(ax1, bx1))
+    inter_h = max(0.0, min(ay2, by2) - max(ay1, by1))
+    inter = inter_w * inter_h
+
+    area_a = max(0.0, ax2 - ax1) * max(0.0, ay2 - ay1)
+    area_b = max(0.0, bx2 - bx1) * max(0.0, by2 - by1)
+    union = area_a + area_b - inter
+    return inter / union if union > 0 else 0.0
+
+
+def _xywh_to_xyxy_corners(box: Sequence[float]) -> tuple[float, float, float, float]:
+    x, y, w, h = (float(v) for v in box)
+    return (x, y, x + w, y + h)
 
 
 def aggregate_scores(scores: Iterable[RunScore]) -> RunScore:

--- a/vrs/eval/schemas.py
+++ b/vrs/eval/schemas.py
@@ -1,10 +1,8 @@
 """Data contracts for the eval harness.
 
-Ground truth is event-level (class name + time window in the source video);
-this matches how Le2i / UCF-Crime and the bulk of public VAD datasets label
-video, and is coarser than D-Fire's per-frame bboxes — a bbox-level scorer
-can be added later on top of the same ``GroundTruthEvent`` shape by adding a
-``bbox_xywh_norm`` field.
+Ground truth is event-level (class name + time window in the source media).
+Image datasets such as D-Fire use a degenerate ``0.0`` to ``0.0`` event window
+and can optionally attach normalized YOLO boxes for bbox-level scoring.
 """
 
 from __future__ import annotations
@@ -15,16 +13,21 @@ from pathlib import Path
 
 @dataclass(frozen=True)
 class GroundTruthEvent:
-    """One labeled event in a source video."""
+    """One labeled event in a source video or image.
+
+    ``bbox_xywh_norm`` uses normalized VRS alert coordinates:
+    ``(x_min, y_min, width, height)``.
+    """
 
     class_name: str
     start_s: float
     end_s: float
+    bbox_xywh_norm: tuple[float, float, float, float] | None = None
 
 
 @dataclass
 class EvalItem:
-    """One video + its ground-truth events (what a Dataset iterator yields)."""
+    """One media item + its ground-truth events (what a Dataset iterator yields)."""
 
     video_path: Path
     events: list[GroundTruthEvent] = field(default_factory=list)

--- a/vrs/ingest/stream_reader.py
+++ b/vrs/ingest/stream_reader.py
@@ -12,11 +12,14 @@ from __future__ import annotations
 
 import time
 from collections.abc import Iterator
+from pathlib import Path
 
 import cv2
 import numpy as np
 
 from ..schemas import Frame
+
+_IMAGE_SUFFIXES = {".bmp", ".jpeg", ".jpg", ".png", ".webp"}
 
 
 class StreamReader:
@@ -35,6 +38,7 @@ class StreamReader:
         self._cap: cv2.VideoCapture | None = None
         self._native_fps: float = 0.0
         self._is_live = self._looks_like_live(source)
+        self._is_image = not self._is_live and Path(source).suffix.lower() in _IMAGE_SUFFIXES
 
     @staticmethod
     def _looks_like_live(s: str) -> bool:
@@ -57,6 +61,13 @@ class StreamReader:
         return cv2.bitwise_and(img, img, mask=mask)
 
     def __iter__(self) -> Iterator[Frame]:
+        if self._is_image:
+            image = cv2.imread(self.source, cv2.IMREAD_COLOR)
+            if image is None:
+                raise RuntimeError(f"Failed to open image source: {self.source}")
+            yield Frame(index=0, pts_s=0.0, image=self._apply_roi(image))
+            return
+
         self._open()
         assert self._cap is not None
 

--- a/vrs/schemas.py
+++ b/vrs/schemas.py
@@ -65,6 +65,21 @@ class CandidateAlert:
             "num_keyframes": len(self.keyframes),
         }
 
+    def detector_bbox_xywh_norm(self) -> tuple[float, float, float, float] | None:
+        """Return the highest-score peak detector box as normalized x/y/w/h."""
+        if not self.peak_detections or not self.keyframes:
+            return None
+        height, width = self.keyframes[-1].shape[:2]
+        if width <= 0 or height <= 0:
+            return None
+        det = max(self.peak_detections, key=lambda item: item.score)
+        x1, y1, x2, y2 = det.xyxy
+        x1 = _clamp(float(x1) / width)
+        y1 = _clamp(float(y1) / height)
+        x2 = _clamp(float(x2) / width)
+        y2 = _clamp(float(y2) / height)
+        return (x1, y1, max(0.0, x2 - x1), max(0.0, y2 - y1))
+
 
 @dataclass
 class VerifiedAlert:
@@ -82,16 +97,19 @@ class VerifiedAlert:
 
     def to_json(self) -> dict[str, Any]:
         out = self.candidate.summary()
+        bbox = self.bbox_xywh_norm or self.candidate.detector_bbox_xywh_norm()
         out.update(
             true_alert=bool(self.true_alert),
             confidence=float(self.confidence),
             false_negative_class=self.false_negative_class,
             rationale=self.rationale,
-            bbox_xywh_norm=(
-                [float(x) for x in self.bbox_xywh_norm] if self.bbox_xywh_norm is not None else None
-            ),
+            bbox_xywh_norm=([float(x) for x in bbox] if bbox is not None else None),
             trajectory_xy_norm=[[float(x), float(y)] for (x, y) in self.trajectory_xy_norm],
             verifier_raw=self.verifier_raw,
             thumbnail_path=self.thumbnail_path,
         )
         return out
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, value))


### PR DESCRIPTION
## Summary
- add a registered D-Fire adapter for images/labels YOLO datasets
- preserve bbox labels as VRS-normalized x/y/w/h and add optional bbox IoU scoring
- support still-image eval inputs and document the D-Fire mini layout

## Validation
- python -m ruff check .
- python -m pytest -q (186 passed)