### PR TITLE
feat(policy): support per-class verifier windows

### DIFF
--- a/configs/policies/safety.yaml
+++ b/configs/policies/safety.yaml
@@ -9,6 +9,8 @@
 #   min_score   : per-class detector score floor (overrides config.detector.conf_floor up)
 #   min_persist_frames : how many of the last `event_state.window` frames must
 #                        contain a hit before we promote to a CandidateAlert
+#   verifier_window_s  : optional per-class verifier clip window, overriding
+#                        verifier.context_window_s from the runtime config
 
 watch:
   - name: fire
@@ -24,6 +26,7 @@ watch:
     severity: high
     min_score: 0.25
     min_persist_frames: 2
+    verifier_window_s: 12.0
 
   - name: falldown
     detector:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -90,6 +90,8 @@ def test_load_default_safety_policy_has_expected_events(tmp_path):
     policy = load_watch_policy(Path(__file__).parent.parent / "configs/policies/safety.yaml")
     names = policy.names()
     assert {"fire", "smoke", "falldown", "weapon"}.issubset(names)
+    assert policy["fire"].verifier_window_s is None
+    assert policy["smoke"].verifier_window_s == pytest.approx(12.0)
     # YOLOE vocabulary is the *flat* list — counts >= number of events
     assert len(policy.yoloe_vocabulary()) >= len(names)
     # round-trip prompt index → event name works
@@ -109,6 +111,26 @@ def test_policy_rejects_invalid_severity(tmp_path):
     )
     with pytest.raises(ValueError):
         load_watch_policy(bad)
+
+
+def test_policy_loads_optional_verifier_window(tmp_path):
+    policy_path = tmp_path / "policy.yaml"
+    policy_path.write_text(
+        "watch:\n"
+        "  - name: smoke\n"
+        "    detector: ['smoke']\n"
+        "    verifier: 'thick smoke'\n"
+        "    verifier_window_s: 8.5\n"
+        "  - name: fire\n"
+        "    detector: ['fire']\n"
+        "    verifier: 'open flames'\n",
+        encoding="utf-8",
+    )
+
+    policy = load_watch_policy(policy_path)
+
+    assert policy["smoke"].verifier_window_s == pytest.approx(8.5)
+    assert policy["fire"].verifier_window_s is None
 
 
 # ─── event-state ───────────────────────────────────────────────────────
@@ -136,6 +158,55 @@ def _frame(idx: int, pts: float):
 
 def _det(name: str = "fire", score: float = 0.9):
     return Detection(class_name=name, score=score, xyxy=(10.0, 10.0, 30.0, 30.0))
+
+
+def test_event_state_uses_global_verifier_window_by_default():
+    q = EventStateQueue(
+        _make_policy(min_persist=1),
+        window=4,
+        cooldown_s=0.0,
+        keyframes=10,
+        context_window_s=1.0,
+    )
+    for idx, pts in enumerate([5.0, 8.0, 9.25]):
+        assert q.step(_frame(idx, pts), []) == []
+
+    alerts = q.step(_frame(3, 10.0), [_det()])
+
+    assert len(alerts) == 1
+    assert alerts[0].keyframe_pts == pytest.approx([9.25, 10.0])
+
+
+def test_event_state_uses_per_class_verifier_window_override():
+    from vrs.policy.watch_policy import WatchItem
+
+    policy = WatchPolicy(
+        [
+            WatchItem(
+                name="smoke",
+                detector_prompts=["smoke"],
+                verifier_prompt="thick smoke",
+                severity="high",
+                min_score=0.25,
+                min_persist_frames=1,
+                verifier_window_s=3.0,
+            )
+        ]
+    )
+    q = EventStateQueue(
+        policy,
+        window=4,
+        cooldown_s=0.0,
+        keyframes=10,
+        context_window_s=1.0,
+    )
+    for idx, pts in enumerate([5.0, 7.5, 9.25]):
+        assert q.step(_frame(idx, pts), []) == []
+
+    alerts = q.step(_frame(3, 10.0), [_det("smoke")])
+
+    assert len(alerts) == 1
+    assert alerts[0].keyframe_pts == pytest.approx([7.5, 9.25, 10.0])
 
 
 def test_event_state_requires_min_persist():

--- a/vrs/policy/watch_policy.py
+++ b/vrs/policy/watch_policy.py
@@ -8,6 +8,7 @@ A watch policy lists named events in plain English. Each item has:
   severity  : info | low | medium | high | critical
   min_score : per-class score floor (overrides config.detector.conf_floor up).
   min_persist_frames : temporal persistence required to raise a CandidateAlert.
+  verifier_window_s : optional per-event verifier context window override.
 """
 
 from __future__ import annotations
@@ -29,6 +30,7 @@ class WatchItem:
     severity: str
     min_score: float
     min_persist_frames: int
+    verifier_window_s: float | None = None
 
 
 class WatchPolicy:
@@ -108,6 +110,12 @@ def _validate_item(raw: dict) -> WatchItem:
     if min_persist < 1:
         raise ValueError(f"watch[{name}].min_persist_frames must be >= 1")
 
+    verifier_window_s: float | None = None
+    if "verifier_window_s" in raw and raw["verifier_window_s"] is not None:
+        verifier_window_s = float(raw["verifier_window_s"])
+        if verifier_window_s <= 0.0:
+            raise ValueError(f"watch[{name}].verifier_window_s must be > 0")
+
     return WatchItem(
         name=name,
         detector_prompts=detector,
@@ -115,6 +123,7 @@ def _validate_item(raw: dict) -> WatchItem:
         severity=severity,
         min_score=min_score,
         min_persist_frames=min_persist,
+        verifier_window_s=verifier_window_s,
     )
 
 

--- a/vrs/triage/event_state.py
+++ b/vrs/triage/event_state.py
@@ -51,6 +51,14 @@ class EventStateQueue:
         self.cooldown_s = float(cooldown_s)
         self.keyframes = int(keyframes)
         self.context_window_s = float(context_window_s)
+        self._context_window_by_class = {
+            it.name: (
+                float(it.verifier_window_s)
+                if it.verifier_window_s is not None
+                else self.context_window_s
+            )
+            for it in policy
+        }
 
         self._state: dict[str, _ClassState] = {
             it.name: _ClassState(
@@ -62,7 +70,10 @@ class EventStateQueue:
         }
 
         # rolling buffer of (frame, detections) for keyframe extraction
-        ring_len = max(int(context_window_s * target_fps) * 2 + 4, 16)
+        max_context_window_s = max(
+            self._context_window_by_class.values(), default=self.context_window_s
+        )
+        ring_len = max(int(max_context_window_s * target_fps) * 2 + 4, 16)
         self._ring: deque[tuple[Frame, list[Detection]]] = deque(maxlen=ring_len)
 
     # ---- main api ---------------------------------------------------
@@ -114,7 +125,7 @@ class EventStateQueue:
                 state.last_alert_pts_by_track[tid] = frame.pts_s
 
                 if keyframes is None:
-                    keyframes, keyframe_pts = self._sample_keyframes(frame.pts_s)
+                    keyframes, keyframe_pts = self._sample_keyframes(frame.pts_s, name)
 
                 tid_dets = [d for d in peak_dets if d.track_id == tid] or peak_dets
                 alerts.append(
@@ -134,12 +145,13 @@ class EventStateQueue:
 
     # ---- helpers ----------------------------------------------------
 
-    def _sample_keyframes(self, peak_pts_s: float):
+    def _sample_keyframes(self, peak_pts_s: float, class_name: str):
         """Pick ``self.keyframes`` evenly-spaced frames around the peak."""
         if not self._ring:
             return [], []
-        t_lo = peak_pts_s - self.context_window_s
-        t_hi = peak_pts_s + self.context_window_s
+        context_window_s = self._context_window_by_class.get(class_name, self.context_window_s)
+        t_lo = peak_pts_s - context_window_s
+        t_hi = peak_pts_s + context_window_s
         candidates = [pair for pair in self._ring if t_lo <= pair[0].pts_s <= t_hi]
         if not candidates:
             candidates = list(self._ring)


### PR DESCRIPTION
## Summary
- add optional watch-policy verifier_window_s per item
- use per-class verifier windows when sampling candidate keyframes
- document an example smoke override in configs/policies/safety.yaml

## Tests
- python -m pytest -q