### PR TITLE
[codex] feat(runtime): add OpenAI-compatible VLM backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,30 @@ Outputs:
 - `runs/<name>/thumbnails/*.jpg` — one event image per alert, with detector/verifier overlays
 - `runs/<name>/annotated.mp4` — optional debug/demo overlay video when `sink.write_annotated: true`
 
+### Served OpenAI-compatible verifier
+
+To compare the local Cosmos baseline against a served Qwen/vLLM/SGLang-style
+VLM, point the verifier at an OpenAI-compatible chat-completions endpoint:
+
+```yaml
+verifier:
+  enabled: true
+  backend: openai_compatible
+  model_id: qwen-vl-served
+  base_url: http://localhost:8000/v1
+  api_key_env: VRS_VLM_API_KEY
+  max_new_tokens: 512
+  temperature: 0.0
+```
+
+The backend posts to `${base_url}/chat/completions` with the same system prompt,
+user prompt, and keyframe list used by the local verifier. Each BGR keyframe is
+JPEG-encoded and sent as a `data:image/jpeg;base64,...` `image_url` content item
+after the text prompt. When the verifier supplies its JSON schema, the backend
+passes it as `response_format: {type: "json_schema", ...}`; if a server ignores
+that field, VRS still applies the same verifier JSON parsing and failure policy
+to the returned text.
+
 ## Smoke-test on your GPU (e.g. RTX 5080)
 
 1. **Generate synthetic plumbing-test clips** (no network, no datasets):

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -44,11 +44,14 @@ verifier:
   # not a final model choice. Internal benchmarks and 2026 Qwen releases
   # justify adding/evaluating Qwen3.5/Qwen3.6-class verifier backends before
   # production model lock-in.
-  backend: "transformers"    # transformers (default) | vllm | trtllm (reserved).
+  backend: "transformers"    # transformers (default) | vllm | openai_compatible | trtllm (reserved).
                              # vllm: higher gen throughput, needs `uv sync --extra vllm`
                              # and a GPU-local smoke run before prod — see vrs/runtime/vllm_cosmos.py.
-                             # planned: qwen/openai-compatible served VLM backend.
+                             # openai_compatible: served VLM at base_url/chat/completions.
   model_id: "nvidia/Cosmos-Reason2-2B"  # baseline; compare against Qwen candidates via eval
+  base_url: null             # e.g. http://localhost:8000/v1 for openai_compatible
+  api_key_env: null          # optional env var name containing bearer token
+  timeout_s: 60.0            # HTTP request timeout for served backends
   dtype: "bf16"              # "bf16" | "fp16" | "w4a16" (requires bitsandbytes)
   device: "cuda"
   context_window_s: 4.0      # video clip handed to the VLM: ±2s around the alert peak

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -7,8 +7,11 @@ spinning up a GPU."""
 
 from __future__ import annotations
 
+import json
 import sys
 import types
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
 
 import numpy as np
 import pytest
@@ -88,7 +91,7 @@ def test_cosmos_factory_and_protocol_names_remain_aliases():
 def test_known_backends_set_matches_factory_branches():
     """If we add a backend name we must also update the _KNOWN_BACKENDS
     advertisement — this pin catches silent drift."""
-    assert {"transformers", "vllm", "trtllm"} == _KNOWN_BACKENDS
+    assert {"transformers", "vllm", "openai_compatible", "trtllm"} == _KNOWN_BACKENDS
 
 
 # ─── vLLM backend ─────────────────────────────────────────────────────
@@ -207,6 +210,101 @@ def test_vllm_backend_empty_frames_raises():
     finally:
         sys.modules.pop("vllm", None)
         sys.modules.pop("vllm.sampling_params", None)
+
+
+# ─── OpenAI-compatible served backend ─────────────────────────────────
+
+
+def test_openai_compatible_backend_posts_multimodal_chat_completion(monkeypatch):
+    captured: dict = {}
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers["Content-Length"])
+            captured["path"] = self.path
+            captured["authorization"] = self.headers.get("Authorization")
+            captured["payload"] = json.loads(self.rfile.read(length))
+            body = (
+                b'{"choices":[{"message":{"content":"{\\"true_alert\\":true,'
+                b'\\"confidence\\":0.91,\\"false_negative_class\\":null,'
+                b'\\"rationale\\":\\"ok\\"}"}}]}'
+            )
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    fake_cv2 = types.ModuleType("cv2")
+    fake_cv2.imencode = lambda ext, arr: (True, np.frombuffer(b"jpeg-bytes", dtype=np.uint8))
+    monkeypatch.setitem(sys.modules, "cv2", fake_cv2)
+    monkeypatch.setenv("VRS_VLM_API_KEY", "secret-token")
+
+    from vrs.runtime.cosmos_loader import CosmosConfig
+    from vrs.runtime.openai_compatible_vlm import OpenAICompatibleVLMBackend
+
+    try:
+        backend = OpenAICompatibleVLMBackend(
+            CosmosConfig(
+                model_id="qwen-vl-served",
+                max_new_tokens=64,
+                temperature=0.0,
+                base_url=f"http://127.0.0.1:{server.server_port}/v1",
+                api_key_env="VRS_VLM_API_KEY",
+            )
+        )
+        schema = {"type": "object", "properties": {"true_alert": {"type": "boolean"}}}
+
+        out = backend.chat_video(
+            "sys",
+            "user",
+            [np.zeros((8, 8, 3), dtype=np.uint8)],
+            response_schema=schema,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert out.startswith("{")
+    assert captured["path"] == "/v1/chat/completions"
+    assert captured["authorization"] == "Bearer secret-token"
+
+    payload = captured["payload"]
+    assert payload["model"] == "qwen-vl-served"
+    assert payload["max_tokens"] == 64
+    assert payload["temperature"] == pytest.approx(0.0)
+    assert payload["response_format"]["json_schema"]["schema"] == schema
+
+    user_content = payload["messages"][1]["content"]
+    assert user_content[0] == {"type": "text", "text": "user"}
+    assert user_content[1]["type"] == "image_url"
+    assert user_content[1]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+def test_openai_compatible_backend_requires_base_url():
+    from vrs.runtime.cosmos_loader import CosmosConfig
+    from vrs.runtime.openai_compatible_vlm import OpenAICompatibleVLMBackend
+
+    with pytest.raises(ValueError, match="base_url"):
+        OpenAICompatibleVLMBackend(CosmosConfig(model_id="qwen-vl-served"))
+
+
+def test_openai_compatible_backend_empty_frames_raises():
+    from vrs.runtime.cosmos_loader import CosmosConfig
+    from vrs.runtime.openai_compatible_vlm import OpenAICompatibleVLMBackend
+
+    backend = OpenAICompatibleVLMBackend(
+        CosmosConfig(model_id="qwen-vl-served", base_url="http://127.0.0.1:1/v1")
+    )
+    with pytest.raises(ValueError, match="at least one frame"):
+        backend.chat_video("sys", "user", [])
 
 
 # ─── verifier integrates cleanly through the Protocol ─────────────────

--- a/vrs/multistream/pipeline.py
+++ b/vrs/multistream/pipeline.py
@@ -133,6 +133,9 @@ class MultiStreamPipeline:
                     max_new_tokens=int(ver_cfg.get("max_new_tokens", 1024)),
                     temperature=float(ver_cfg.get("temperature", 0.2)),
                     clip_fps=int(ver_cfg.get("clip_fps", 4)),
+                    base_url=ver_cfg.get("base_url"),
+                    api_key_env=ver_cfg.get("api_key_env"),
+                    timeout_s=float(ver_cfg.get("timeout_s", 60.0)),
                 ),
                 backend=ver_cfg.get("backend", "transformers"),
             )

--- a/vrs/pipeline.py
+++ b/vrs/pipeline.py
@@ -110,6 +110,9 @@ class VRSPipeline:
                     max_new_tokens=int(ver_cfg.get("max_new_tokens", 1024)),
                     temperature=float(ver_cfg.get("temperature", 0.2)),
                     clip_fps=int(ver_cfg.get("clip_fps", 4)),
+                    base_url=ver_cfg.get("base_url"),
+                    api_key_env=ver_cfg.get("api_key_env"),
+                    timeout_s=float(ver_cfg.get("timeout_s", 60.0)),
                 ),
                 backend=ver_cfg.get("backend", "transformers"),
             )

--- a/vrs/runtime/backends.py
+++ b/vrs/runtime/backends.py
@@ -12,6 +12,8 @@ Backends shipped:
 * ``vllm`` — higher generation throughput via paged KV cache + in-flight
   batching. Optional dep (``uv sync --extra vllm``); implementation
   lives in ``vllm_cosmos``.
+* ``openai_compatible`` — served VLM over an OpenAI-compatible
+  ``/chat/completions`` endpoint.
 * ``trtllm`` — reserved (a future addition that produces the biggest
   latency win when paired with speculative decoding).
 
@@ -60,7 +62,7 @@ CosmosBackend = VLMBackend
 # factory
 # ──────────────────────────────────────────────────────────────────────
 
-_KNOWN_BACKENDS = {"transformers", "vllm", "trtllm"}
+_KNOWN_BACKENDS = {"transformers", "vllm", "openai_compatible", "trtllm"}
 
 
 def build_vlm_backend(cfg, backend: str = "transformers") -> VLMBackend:
@@ -80,6 +82,10 @@ def build_vlm_backend(cfg, backend: str = "transformers") -> VLMBackend:
         from .vllm_cosmos import VLLMCosmosBackend
 
         return VLLMCosmosBackend(cfg)
+    if name in ("openai_compatible", "openai-compatible", "openai"):
+        from .openai_compatible_vlm import OpenAICompatibleVLMBackend
+
+        return OpenAICompatibleVLMBackend(cfg)
     if name == "trtllm":
         raise NotImplementedError(
             "the trtllm backend is a planned follow-on once the vllm path "

--- a/vrs/runtime/cosmos_loader.py
+++ b/vrs/runtime/cosmos_loader.py
@@ -33,6 +33,9 @@ class VLMConfig:
     max_new_tokens: int = 1024
     temperature: float = 0.2
     clip_fps: int = 4  # Cosmos-Reason2-2B was trained at FPS=4
+    base_url: str | None = None
+    api_key_env: str | None = None
+    timeout_s: float = 60.0
 
 
 CosmosConfig = VLMConfig

--- a/vrs/runtime/openai_compatible_vlm.py
+++ b/vrs/runtime/openai_compatible_vlm.py
@@ -1,0 +1,133 @@
+"""OpenAI-compatible served VLM verifier runtime.
+
+This backend keeps the verifier's local ``chat_video`` contract but sends the
+request to a ``/chat/completions`` endpoint. Frames are encoded as JPEG data
+URLs and attached as OpenAI-style ``image_url`` content items, which is the
+common multimodal surface exposed by vLLM, SGLang, and other compatible
+servers.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
+
+import numpy as np
+
+
+def _frame_to_jpeg_data_url(frame_bgr: np.ndarray) -> str:
+    import cv2
+
+    ok, encoded = cv2.imencode(".jpg", frame_bgr)
+    if not ok:
+        raise ValueError("failed to JPEG-encode verifier frame")
+    data = base64.b64encode(encoded.tobytes()).decode("ascii")
+    return f"data:image/jpeg;base64,{data}"
+
+
+def _completion_text(payload: dict[str, Any]) -> str:
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return ""
+    message = choices[0].get("message") if isinstance(choices[0], dict) else None
+    if not isinstance(message, dict):
+        return ""
+
+    content = message.get("content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict) and isinstance(item.get("text"), str):
+                parts.append(item["text"])
+        return "".join(parts)
+    return ""
+
+
+class OpenAICompatibleVLMBackend:
+    """VLM backend for OpenAI-compatible chat-completions servers."""
+
+    def __init__(self, cfg):
+        if not cfg.base_url:
+            raise ValueError(
+                "openai_compatible verifier backend requires verifier.base_url "
+                "(for example http://localhost:8000/v1)"
+            )
+        self.cfg = cfg
+        self.base_url = str(cfg.base_url).rstrip("/") + "/"
+        self.api_key = os.environ.get(cfg.api_key_env) if cfg.api_key_env else None
+        self.timeout_s = float(getattr(cfg, "timeout_s", 60.0))
+
+    def chat_video(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        frames_bgr: list[np.ndarray],
+        *,
+        clip_fps: int | None = None,
+        response_schema: dict[str, Any] | None = None,
+    ) -> str:
+        if not frames_bgr:
+            raise ValueError("chat_video requires at least one frame")
+
+        user_content: list[dict[str, Any]] = [{"type": "text", "text": user_prompt}]
+        user_content.extend(
+            {
+                "type": "image_url",
+                "image_url": {"url": _frame_to_jpeg_data_url(frame), "detail": "auto"},
+            }
+            for frame in frames_bgr
+        )
+
+        payload: dict[str, Any] = {
+            "model": self.cfg.model_id,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_content},
+            ],
+            "max_tokens": int(self.cfg.max_new_tokens),
+            "temperature": float(self.cfg.temperature),
+        }
+        if response_schema is not None:
+            payload["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "vrs_verifier_response",
+                    "schema": response_schema,
+                    "strict": True,
+                },
+            }
+
+        body = json.dumps(payload).encode("utf-8")
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        req = Request(
+            urljoin(self.base_url, "chat/completions"),
+            data=body,
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urlopen(req, timeout=self.timeout_s) as resp:
+                raw = resp.read().decode("utf-8")
+        except HTTPError as e:
+            detail = e.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"OpenAI-compatible VLM request failed with HTTP {e.code}: {detail}"
+            ) from e
+        except URLError as e:
+            raise RuntimeError(f"OpenAI-compatible VLM request failed: {e.reason}") from e
+
+        try:
+            response = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise RuntimeError("OpenAI-compatible VLM returned invalid JSON response") from e
+        return _completion_text(response)


### PR DESCRIPTION
## Summary

- Add `openai_compatible` verifier backend for OpenAI-compatible `/chat/completions` VLM servers.
- Encode verifier keyframes as JPEG data URL `image_url` content items and pass the existing verifier JSON schema through `response_format`.
- Wire `base_url`, `api_key_env`, and `timeout_s` through single-stream and multistream configs, with README/default config documentation.
- Add fake local HTTP server tests so no remote VLM service is required.

## Validation

- `python -m ruff check .`
- `python -m pytest -q`
