### PR TITLE
[codex] Add multistream drain shutdown mode

### DIFF
--- a/configs/multistream.yaml
+++ b/configs/multistream.yaml
@@ -44,6 +44,13 @@ multistream:
   # pipeline. Raise if you have many streams and want quieter logs.
   drop_log_interval_s: 5.0
 
+  # Shutdown behavior:
+  #   fast   — stop all workers immediately and close queues quickly.
+  #   drain  — stop decoders first, then let frame/candidate/sink queues drain
+  #            until shutdown_drain_timeout_s elapses.
+  shutdown_mode: fast
+  shutdown_drain_timeout_s: 10.0
+
 # Stream manifest — one entry per camera / file.
 # ``id`` becomes the output subdirectory name:
 # runs/<out>/<id>/{alerts.jsonl,thumbnails/*.jpg}

--- a/tests/test_multistream.py
+++ b/tests/test_multistream.py
@@ -308,6 +308,147 @@ def test_queue_stats_report_backpressure():
     assert q.qsize() == 2
 
 
+def test_fast_shutdown_sets_worker_stop_immediately():
+    from vrs.multistream.pipeline import MultiStreamPipeline
+
+    p = MultiStreamPipeline.__new__(MultiStreamPipeline)
+    p._stop = threading.Event()
+    p._decoder_stop = threading.Event()
+    p._frame_q = BoundedQueue(maxsize=4)
+    p._candidate_q = BoundedQueue(maxsize=4)
+    p._sink_qs = {"s1": BoundedQueue(maxsize=4)}
+    p._decoders = []
+    p._sinks = []
+    p._verifier_worker = None
+    p._calibrator = None
+    saw_stop = threading.Event()
+
+    def _worker():
+        p._stop.wait(timeout=1.0)
+        if p._stop.is_set():
+            saw_stop.set()
+
+    p._detector_worker = threading.Thread(target=_worker, name="detector", daemon=True)
+    p._detector_worker.start()
+
+    p.stop("fast")
+
+    assert p._decoder_stop.is_set()
+    assert p._stop.is_set()
+    assert saw_stop.is_set()
+
+
+def test_drain_shutdown_flushes_frame_candidate_and_sink_queues_without_loss():
+    from vrs.multistream.pipeline import MultiStreamPipeline
+
+    p = MultiStreamPipeline.__new__(MultiStreamPipeline)
+    p._stop = threading.Event()
+    p._decoder_stop = threading.Event()
+    p._shutdown_drain_timeout_s = 2.0
+    p._frame_q = BoundedQueue(maxsize=8)
+    p._candidate_q = BoundedQueue(maxsize=8)
+    sink_q = BoundedQueue(maxsize=8)
+    p._sink_qs = {"s1": sink_q}
+    p._decoders = []
+    p._calibrator = None
+    written: list[str] = []
+
+    for item in ("f1", "f2"):
+        p._frame_q.put(item)
+    p._candidate_q.put("candidate-before-stop")
+    sink_q.put("sink-before-stop")
+
+    def _detector():
+        while True:
+            try:
+                item = p._frame_q.get(timeout=0.05)
+            except TimeoutError:
+                continue
+            except StopIteration:
+                break
+            p._candidate_q.put(f"candidate:{item}")
+
+    def _verifier():
+        while True:
+            try:
+                item = p._candidate_q.get(timeout=0.05)
+            except TimeoutError:
+                continue
+            except StopIteration:
+                break
+            sink_q.put(f"verified:{item}")
+
+    def _sink():
+        while True:
+            try:
+                item = sink_q.get(timeout=0.05)
+            except TimeoutError:
+                continue
+            except StopIteration:
+                break
+            written.append(item)
+
+    p._detector_worker = threading.Thread(target=_detector, name="detector", daemon=True)
+    p._verifier_worker = threading.Thread(target=_verifier, name="verifier", daemon=True)
+    p._sinks = [threading.Thread(target=_sink, name="sink[s1]", daemon=True)]
+    p._detector_worker.start()
+    p._verifier_worker.start()
+    p._sinks[0].start()
+
+    p.stop("drain")
+
+    assert p._stop.is_set()
+    assert set(written) == {
+        "sink-before-stop",
+        "verified:candidate-before-stop",
+        "verified:candidate:f1",
+        "verified:candidate:f2",
+    }
+
+
+def test_drain_shutdown_logs_queue_sizes_and_alive_workers_on_deadline(caplog):
+    import logging
+
+    from vrs.multistream.pipeline import MultiStreamPipeline
+
+    p = MultiStreamPipeline.__new__(MultiStreamPipeline)
+    p._stop = threading.Event()
+    p._decoder_stop = threading.Event()
+    p._shutdown_drain_timeout_s = 0.01
+    p._frame_q = BoundedQueue(maxsize=4)
+    p._candidate_q = BoundedQueue(maxsize=4)
+    p._sink_qs = {"s1": BoundedQueue(maxsize=4)}
+    p._decoders = []
+    p._verifier_worker = None
+    p._sinks = []
+    p._calibrator = None
+    release = threading.Event()
+
+    p._frame_q.put("still-buffered")
+
+    def _blocked_detector():
+        release.wait(timeout=1.0)
+
+    p._detector_worker = threading.Thread(
+        target=_blocked_detector,
+        name="detector",
+        daemon=True,
+    )
+    p._detector_worker.start()
+
+    try:
+        with caplog.at_level(logging.WARNING, logger="vrs.multistream.pipeline"):
+            p.stop("drain")
+    finally:
+        release.set()
+        p._detector_worker.join(timeout=1.0)
+
+    messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("drain shutdown deadline exceeded" in m for m in messages)
+    assert any("frame_q=1" in m for m in messages)
+    assert any("alive workers: detector" in m for m in messages)
+
+
 def test_drop_delta_logger_warns_on_increase(caplog):
     """Regression: when queue drop counters grow between samples, the
     pipeline must surface the jump as a WARNING naming every affected

--- a/vrs/multistream/pipeline.py
+++ b/vrs/multistream/pipeline.py
@@ -149,6 +149,13 @@ class MultiStreamPipeline:
         # --- queues ---
         ms_cfg = config.get("multistream") or {}
         self._stop = threading.Event()
+        self._decoder_stop = threading.Event()
+        self._shutdown_mode = str(ms_cfg.get("shutdown_mode", "fast")).lower()
+        if self._shutdown_mode not in {"fast", "drain"}:
+            raise ValueError("multistream.shutdown_mode must be 'fast' or 'drain'")
+        self._shutdown_drain_timeout_s = float(ms_cfg.get("shutdown_drain_timeout_s", 10.0))
+        if self._shutdown_drain_timeout_s < 0:
+            raise ValueError("multistream.shutdown_drain_timeout_s must be >= 0")
         self._frame_q = BoundedQueue(
             maxsize=int(ms_cfg.get("frame_queue_size", max(32, 4 * len(streams)))),
             policy=DropPolicy(ms_cfg.get("frame_drop_policy", "drop_oldest")),
@@ -245,7 +252,7 @@ class MultiStreamPipeline:
                     stream_id=s.id,
                     reader=reader,
                     frame_q=self._frame_q,
-                    stop_event=self._stop,
+                    stop_event=self._decoder_stop,
                 )
             )
 
@@ -304,7 +311,17 @@ class MultiStreamPipeline:
         finally:
             self.stop()
 
-    def stop(self) -> None:
+    def stop(self, mode: str | None = None) -> None:
+        shutdown_mode = str(mode or getattr(self, "_shutdown_mode", "fast")).lower()
+        if shutdown_mode == "drain":
+            self._stop_drain()
+        elif shutdown_mode == "fast":
+            self._stop_fast()
+        else:
+            raise ValueError("shutdown mode must be 'fast' or 'drain'")
+
+    def _stop_fast(self) -> None:
+        self._decoder_stop_event().set()
         self._stop.set()
         self._frame_q.close()
         self._candidate_q.close()
@@ -338,11 +355,93 @@ class MultiStreamPipeline:
         if self._calibrator is not None:
             self._calibrator.close()
 
+    def _stop_drain(self) -> None:
+        timeout_s = float(getattr(self, "_shutdown_drain_timeout_s", 10.0))
+        deadline = time.monotonic() + timeout_s
+        deadline_exceeded = False
+
+        self._decoder_stop_event().set()
+
+        for d in self._decoders:
+            if not self._join_until_deadline(d, deadline):
+                deadline_exceeded = True
+
+        self._frame_q.close()
+        if self._detector_worker and not self._join_until_deadline(self._detector_worker, deadline):
+            deadline_exceeded = True
+
+        self._candidate_q.close()
+        if self._verifier_worker and not self._join_until_deadline(self._verifier_worker, deadline):
+            deadline_exceeded = True
+
+        for q in self._sink_qs.values():
+            q.close()
+        for w in self._sinks:
+            if not self._join_until_deadline(w, deadline):
+                deadline_exceeded = True
+
+        if deadline_exceeded:
+            self._log_drain_deadline_exceeded(timeout_s)
+            self._stop.set()
+            self._frame_q.close()
+            self._candidate_q.close()
+            for q in self._sink_qs.values():
+                q.close()
+        else:
+            self._stop.set()
+
+        if self._calibrator is not None:
+            self._calibrator.close()
+
     @staticmethod
     def _join_or_track_hung(thread: threading.Thread, timeout: float, hung: list[str]) -> None:
         thread.join(timeout=timeout)
         if thread.is_alive():
             hung.append(f"{thread.name}(>{timeout:g}s)")
+
+    @staticmethod
+    def _join_until_deadline(thread: threading.Thread, deadline: float) -> bool:
+        timeout = max(0.0, deadline - time.monotonic())
+        thread.join(timeout=timeout)
+        return not thread.is_alive()
+
+    def _decoder_stop_event(self) -> threading.Event:
+        event = getattr(self, "_decoder_stop", None)
+        if event is None:
+            event = self._stop
+            self._decoder_stop = event
+        return event
+
+    def _log_drain_deadline_exceeded(self, timeout_s: float) -> None:
+        queue_sizes = self._queue_sizes()
+        queue_parts = ", ".join(f"{name}={size}" for name, size in queue_sizes.items())
+        alive = self._alive_worker_names()
+        alive_part = ", ".join(alive) if alive else "none"
+        logger.warning(
+            "drain shutdown deadline exceeded after %.2fs; remaining queues: %s; alive workers: %s",
+            timeout_s,
+            queue_parts,
+            alive_part,
+        )
+
+    def _queue_sizes(self) -> dict[str, int]:
+        out = {
+            "frame_q": self._frame_q.qsize(),
+            "candidate_q": self._candidate_q.qsize(),
+        }
+        for sid, q in self._sink_qs.items():
+            out[f"sink[{sid}]"] = q.qsize()
+        return out
+
+    def _alive_worker_names(self) -> list[str]:
+        threads: list[threading.Thread] = []
+        threads.extend(getattr(self, "_decoders", []))
+        for attr in ("_detector_worker", "_verifier_worker"):
+            worker = getattr(self, attr, None)
+            if worker is not None:
+                threads.append(worker)
+        threads.extend(getattr(self, "_sinks", []))
+        return [t.name for t in threads if t.is_alive()]
 
     # ---- backpressure diagnostics -----------------------------------
 


### PR DESCRIPTION
## Summary
- Add configurable `multistream.shutdown_mode` with `fast` and deadline-bounded `drain` behavior.
- Split decoder stop from downstream worker stop so drain mode closes frame, candidate, and sink queues only after each producer stage exits.
- Log remaining queue sizes and alive workers when the drain deadline is exceeded.
- Document the shutdown knobs in `configs/multistream.yaml` and add CPU-only lifecycle tests.

## Validation
- `python -m pytest -q` (180 passed)