### PR TITLE
ci(eval): harden report structure validation

### DIFF
--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -792,6 +792,13 @@ def test_gate_rejects_malformed_report():
         compare_reports({}, _report({"fire": 0.8}))
 
 
+def test_gate_rejects_non_object_report():
+    from vrs.eval.ci import compare_reports
+
+    with pytest.raises(ValueError, match="expected object at 'baseline'"):
+        compare_reports([], _report({"fire": 0.8}))
+
+
 def test_gate_rejects_structural_metric_errors():
     from vrs.eval.ci import compare_reports
 
@@ -803,6 +810,21 @@ def test_gate_rejects_structural_metric_errors():
         compare_reports(baseline, current)
 
 
+def test_gate_treats_null_quality_signals_as_zero():
+    from vrs.eval.ci import compare_reports
+
+    baseline = _schema_v1_report({"fire": 0.80}, overall_f1=0.80)
+    current = _schema_v1_report({"fire": 0.80}, overall_f1=0.80)
+    current["quality_signals"]["verifier_flip_rate"] = None
+    current["quality_signals"]["false_negative_flag_rate"] = None
+
+    result = compare_reports(baseline, current)
+
+    assert result.passed is True
+    assert result.current_flip_rate == 0.0
+    assert result.current_fn_flag_rate == 0.0
+
+
 def test_gate_cli_exit_codes(tmp_path: Path):
     import json as _json
 
@@ -812,15 +834,18 @@ def test_gate_cli_exit_codes(tmp_path: Path):
     current_pass = tmp_path / "current_pass.json"
     current_fail = tmp_path / "current_fail.json"
     current_invalid = tmp_path / "current_invalid.json"
+    current_non_object = tmp_path / "current_non_object.json"
 
     baseline.write_text(_json.dumps(_report({"fire": 0.80}, overall_f1=0.80)))
     current_pass.write_text(_json.dumps(_report({"fire": 0.79}, overall_f1=0.79)))
     current_fail.write_text(_json.dumps(_report({"fire": 0.50}, overall_f1=0.50)))
     current_invalid.write_text(_json.dumps({"metrics": {"per_class": {"fire": {}}}}))
+    current_non_object.write_text(_json.dumps([]))
 
     assert ci_main(["--baseline", str(baseline), "--current", str(current_pass)]) == 0
     assert ci_main(["--baseline", str(baseline), "--current", str(current_fail)]) == 1
     assert ci_main(["--baseline", str(baseline), "--current", str(current_invalid)]) == 2
+    assert ci_main(["--baseline", str(baseline), "--current", str(current_non_object)]) == 2
     assert (
         ci_main(["--baseline", str(baseline), "--current", str(tmp_path / "nonexistent.json")]) == 2
     )

--- a/vrs/eval/ci.py
+++ b/vrs/eval/ci.py
@@ -118,6 +118,21 @@ def _read_f1(value: Any, path: str) -> float:
         raise ReportStructureError(f"expected numeric field '{path}.f1'") from exc
 
 
+def _read_optional_float(
+    metrics: Mapping[str, Any],
+    primary_key: str,
+    legacy_key: str,
+    path: str,
+) -> float:
+    value = metrics.get(primary_key, metrics.get(legacy_key, 0.0))
+    if value is None:
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ReportStructureError(f"expected numeric field '{path}'") from exc
+
+
 def _metrics_section(report: Mapping[str, Any]) -> Mapping[str, Any]:
     if report.get("schema_version") not in (None, SCHEMA_VERSION):
         raise ReportStructureError(
@@ -166,8 +181,10 @@ def compare_reports(
     """
     if max_f1_drop < 0:
         raise ValueError("max_f1_drop must be >= 0")
-    if not _metrics_section(baseline) or not _metrics_section(current):
-        raise ValueError("both reports must have either a 'metrics' or 'aggregate' key")
+    baseline = _as_mapping(baseline, "baseline")
+    current = _as_mapping(current, "current")
+    _metrics_section(baseline)
+    _metrics_section(current)
 
     b_pc = _per_class_f1(baseline)
     c_pc = _per_class_f1(current)
@@ -215,17 +232,29 @@ def compare_reports(
         per_class=per_class,
         overall=overall,
         max_f1_drop=max_f1_drop,
-        baseline_flip_rate=float(
-            b_quality.get("verifier_flip_rate", b_quality.get("flip_rate", 0.0))
+        baseline_flip_rate=_read_optional_float(
+            b_quality,
+            "verifier_flip_rate",
+            "flip_rate",
+            "quality_signals.verifier_flip_rate",
         ),
-        current_flip_rate=float(
-            c_quality.get("verifier_flip_rate", c_quality.get("flip_rate", 0.0))
+        current_flip_rate=_read_optional_float(
+            c_quality,
+            "verifier_flip_rate",
+            "flip_rate",
+            "quality_signals.verifier_flip_rate",
         ),
-        baseline_fn_flag_rate=float(
-            b_quality.get("false_negative_flag_rate", b_quality.get("fn_flag_rate", 0.0))
+        baseline_fn_flag_rate=_read_optional_float(
+            b_quality,
+            "false_negative_flag_rate",
+            "fn_flag_rate",
+            "quality_signals.false_negative_flag_rate",
         ),
-        current_fn_flag_rate=float(
-            c_quality.get("false_negative_flag_rate", c_quality.get("fn_flag_rate", 0.0))
+        current_fn_flag_rate=_read_optional_float(
+            c_quality,
+            "false_negative_flag_rate",
+            "fn_flag_rate",
+            "quality_signals.false_negative_flag_rate",
         ),
     )
 


### PR DESCRIPTION
Rebases PR #25 on the updated main after PR #17/#18 landed, and narrows it to the remaining eval CI structural-validation fixes.

Fixes #4.

Validation:
- python -m pytest tests/test_eval.py -q
- python -m pytest -q
- python -m ruff check .
