### PR TITLE
[codex] add Prometheus metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,33 @@ passes it as `response_format: {type: "json_schema", ...}`; if a server ignores
 that field, VRS still applies the same verifier JSON parsing and failure policy
 to the returned text.
 
+## Prometheus Metrics
+
+Metrics are disabled by default. Enable the lightweight scrape endpoint in your
+runtime config:
+
+```yaml
+observability:
+  metrics:
+    enabled: true
+    host: "0.0.0.0"
+    port: 9108
+```
+
+Prometheus can then scrape `http://<host>:9108/metrics`. The endpoint exports
+queue depth and drop counters for multi-stream runs, detector/verifier latency
+histograms, candidate and verified-alert counters, verifier error counters, and
+sink write error counters.
+
+Example scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: vrs
+    static_configs:
+      - targets: ["vrs-appliance.local:9108"]
+```
+
 ## Smoke-test on your GPU (e.g. RTX 5080)
 
 1. **Generate synthetic plumbing-test clips** (no network, no datasets):

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -110,3 +110,11 @@ calibration:
   max_score_cap: 0.80        # never suggest above this
   target_alerts_per_hour: null  # null = tighten-only (safe default).
                                 # set a number to enable the loosen arm.
+
+observability:
+  metrics:
+    # Exposes a Prometheus-compatible text endpoint at /metrics when enabled.
+    # Disabled by default so local runs do not open a listening socket.
+    enabled: false
+    host: "127.0.0.1"
+    port: 9108

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import threading
+import time
+from urllib.request import urlopen
+
+import numpy as np
+
+from vrs.multistream.pipeline import MultiStreamPipeline
+from vrs.multistream.queues import BoundedQueue, DropPolicy
+from vrs.multistream.workers import DetectorWorker, VerifierWorker, _CandidateMsg, _FrameMsg
+from vrs.observability import MetricsRegistry, VRSMetrics, build_metrics
+from vrs.policy.watch_policy import WatchItem, WatchPolicy
+from vrs.schemas import CandidateAlert, Detection, Frame, VerifiedAlert
+
+
+def _policy() -> WatchPolicy:
+    return WatchPolicy(
+        [
+            WatchItem(
+                name="fire",
+                detector_prompts=["fire"],
+                verifier_prompt="open flames",
+                severity="critical",
+                min_score=0.30,
+                min_persist_frames=1,
+            )
+        ]
+    )
+
+
+class _StubDetector:
+    def batch(self, frames: list[Frame]) -> list[list[Detection]]:
+        return [
+            [Detection(class_name="fire", score=0.9, xyxy=(1.0, 1.0, 5.0, 5.0))] for _ in frames
+        ]
+
+
+class _StubVerifier:
+    def verify(self, alert: CandidateAlert) -> VerifiedAlert:
+        return VerifiedAlert(
+            candidate=alert,
+            true_alert=True,
+            confidence=0.95,
+            false_negative_class=None,
+            rationale="stub",
+        )
+
+
+def _candidate() -> CandidateAlert:
+    return CandidateAlert(
+        class_name="fire",
+        severity="critical",
+        start_pts_s=0.0,
+        peak_pts_s=0.5,
+        peak_frame_index=2,
+        peak_detections=[Detection(class_name="fire", score=0.9, xyxy=(0, 0, 1, 1))],
+    )
+
+
+def test_vrs_metrics_render_prometheus_text():
+    registry = MetricsRegistry()
+    metrics = VRSMetrics(registry)
+
+    metrics.set_queue_depth("frame", "all", 3)
+    metrics.set_queue_dropped_total("frame", "all", 2)
+    metrics.inc_candidates("cam01", "fire")
+    metrics.inc_verified_alerts("cam01", "fire", "true_alert")
+    metrics.observe_detector_latency(0.02)
+    metrics.observe_verifier_latency(1.5)
+    metrics.inc_verifier_errors("transformers")
+    metrics.inc_sink_write_errors("cam01")
+
+    text = registry.render()
+
+    assert "# TYPE vrs_queue_depth gauge" in text
+    assert 'vrs_queue_depth{queue="frame",stream_id="all"} 3' in text
+    assert 'vrs_queue_dropped_total{queue="frame",stream_id="all"} 2' in text
+    assert 'vrs_candidates_total{stream_id="cam01",class="fire"} 1' in text
+    assert (
+        'vrs_verified_alerts_total{stream_id="cam01",class="fire",verdict="true_alert"} 1' in text
+    )
+    assert "vrs_detector_latency_seconds_count 1" in text
+    assert "vrs_verifier_latency_seconds_count 1" in text
+    assert 'vrs_verifier_errors_total{backend="transformers"} 1' in text
+    assert 'vrs_sink_write_errors_total{stream_id="cam01"} 1' in text
+
+
+def test_metrics_endpoint_is_disabled_by_default():
+    metrics = build_metrics({})
+    assert metrics.enabled is False
+    assert metrics.url is None
+
+
+def test_metrics_endpoint_serves_registry():
+    metrics = build_metrics(
+        {"observability": {"metrics": {"enabled": True, "host": "127.0.0.1", "port": 0}}}
+    )
+    try:
+        metrics.inc_candidates("cam01", "fire")
+        assert metrics.url is not None
+        with urlopen(metrics.url, timeout=2.0) as response:
+            body = response.read().decode("utf-8")
+    finally:
+        metrics.close()
+
+    assert response.status == 200
+    assert 'vrs_candidates_total{stream_id="cam01",class="fire"} 1' in body
+
+
+def test_multistream_queue_metrics_report_depth_and_drops():
+    registry = MetricsRegistry()
+    metrics = VRSMetrics(registry)
+    pipeline = MultiStreamPipeline.__new__(MultiStreamPipeline)
+    pipeline.metrics = metrics
+    pipeline._frame_q = BoundedQueue(maxsize=1, policy=DropPolicy.DROP_OLDEST)
+    pipeline._candidate_q = BoundedQueue(maxsize=2, policy=DropPolicy.DROP_NEWEST)
+    pipeline._sink_qs = {"cam01": BoundedQueue(maxsize=1, policy=DropPolicy.DROP_OLDEST)}
+
+    pipeline._frame_q.put("a")
+    pipeline._frame_q.put("b")
+    pipeline._candidate_q.put("c")
+    pipeline._sink_qs["cam01"].put("d")
+    pipeline._sink_qs["cam01"].put("e")
+
+    pipeline._record_queue_metrics()
+    text = registry.render()
+
+    assert 'vrs_queue_depth{queue="frame",stream_id="all"} 1' in text
+    assert 'vrs_queue_dropped_total{queue="frame",stream_id="all"} 1' in text
+    assert 'vrs_queue_depth{queue="candidate",stream_id="all"} 1' in text
+    assert 'vrs_queue_depth{queue="sink",stream_id="cam01"} 1' in text
+    assert 'vrs_queue_dropped_total{queue="sink",stream_id="cam01"} 1' in text
+
+
+def test_detector_worker_records_candidate_and_latency_metrics():
+    registry = MetricsRegistry()
+    metrics = VRSMetrics(registry)
+    stop = threading.Event()
+    frame_q = BoundedQueue(maxsize=8)
+    candidate_q = BoundedQueue(maxsize=8)
+
+    worker = DetectorWorker(
+        detector=_StubDetector(),
+        policy=_policy(),
+        frame_q=frame_q,
+        candidate_q=candidate_q,
+        sink_queues={"cam01": BoundedQueue(maxsize=8)},
+        stream_ids=["cam01"],
+        stop_event=stop,
+        batch_size=2,
+        batch_timeout_ms=10,
+        event_state_cfg={"window": 2, "cooldown_s": 0.0},
+        metrics=metrics,
+    )
+    worker.start()
+    img = np.zeros((16, 16, 3), dtype=np.uint8)
+    frame_q.put(_FrameMsg("cam01", Frame(index=0, pts_s=0.0, image=img)))
+    frame_q.put(_FrameMsg("cam01", Frame(index=1, pts_s=0.25, image=img)))
+
+    deadline = time.monotonic() + 1.0
+    while candidate_q.qsize() == 0 and time.monotonic() < deadline:
+        time.sleep(0.02)
+    stop.set()
+    frame_q.close()
+    worker.join(timeout=1.0)
+
+    text = registry.render()
+    assert 'vrs_candidates_total{stream_id="cam01",class="fire"}' in text
+    assert "vrs_detector_latency_seconds_count" in text
+
+
+def test_verifier_worker_records_verified_alert_and_latency_metrics():
+    registry = MetricsRegistry()
+    metrics = VRSMetrics(registry)
+    stop = threading.Event()
+    candidate_q = BoundedQueue(maxsize=8)
+    sink_qs = {"cam01": BoundedQueue(maxsize=8)}
+
+    worker = VerifierWorker(
+        verifier=_StubVerifier(),
+        candidate_q=candidate_q,
+        sink_queues=sink_qs,
+        stop_event=stop,
+        metrics=metrics,
+        verifier_backend="stub",
+    )
+    worker.start()
+    candidate_q.put(_CandidateMsg("cam01", _candidate()))
+
+    time.sleep(0.2)
+    stop.set()
+    candidate_q.close()
+    worker.join(timeout=1.0)
+
+    text = registry.render()
+    assert (
+        'vrs_verified_alerts_total{stream_id="cam01",class="fire",verdict="true_alert"} 1' in text
+    )
+    assert "vrs_verifier_latency_seconds_count" in text

--- a/vrs/multistream/pipeline.py
+++ b/vrs/multistream/pipeline.py
@@ -18,6 +18,7 @@ from typing import Any
 import yaml
 
 from ..calibration import build_calibrator
+from ..observability import build_metrics
 from ..pipeline import load_config
 from ..policy import WatchPolicy, load_watch_policy
 from ..runtime import VLMConfig, build_vlm_backend
@@ -106,6 +107,7 @@ class MultiStreamPipeline:
         self.streams = streams
         self.out_dir = Path(out_dir)
         self.out_dir.mkdir(parents=True, exist_ok=True)
+        self.metrics = build_metrics(config)
 
         # --- shared GPU models (created once, owned by their worker threads) ---
         det_cfg = config["detector"]
@@ -209,6 +211,7 @@ class MultiStreamPipeline:
                     sink_q=self._sink_qs[s.id],
                     stop_event=self._stop,
                     privacy_cfg=self._privacy_cfg,
+                    metrics=self.metrics,
                 )
             )
 
@@ -219,6 +222,8 @@ class MultiStreamPipeline:
             sink_queues=self._sink_qs,
             stop_event=self._stop,
             calibrator=self._calibrator,
+            metrics=self.metrics,
+            verifier_backend=str(self._ver_cfg.get("backend", "disabled")),
         )
 
         # detector worker
@@ -236,6 +241,7 @@ class MultiStreamPipeline:
             verifier_cfg=self._ver_cfg,
             tracker_cfg=self._tracker_cfg,
             target_fps=float(ing["target_fps"]),
+            metrics=self.metrics,
         )
 
         # decoder threads (per stream)
@@ -288,6 +294,7 @@ class MultiStreamPipeline:
         drop_log_interval = float(self._ms_cfg.get("drop_log_interval_s", 5.0))
         last_drop_log = time.monotonic()
         last_drop_snapshot = self._drop_counters()
+        self._record_queue_metrics()
 
         t0 = time.monotonic()
         try:
@@ -301,6 +308,8 @@ class MultiStreamPipeline:
                     self._log_drop_deltas(last_drop_snapshot, cur)
                     last_drop_snapshot = cur
                     last_drop_log = now
+
+                self._record_queue_metrics()
 
                 # join briefly on decoder threads so we exit naturally when files end
                 alive = any(d.is_alive() for d in self._decoders)
@@ -344,6 +353,10 @@ class MultiStreamPipeline:
 
         if self._calibrator is not None:
             self._calibrator.close()
+        self._record_queue_metrics()
+        metrics = getattr(self, "metrics", None)
+        if metrics is not None:
+            metrics.close()
 
     @staticmethod
     def _join_or_track_hung(thread: threading.Thread, timeout: float, hung: list[str]) -> None:
@@ -361,6 +374,18 @@ class MultiStreamPipeline:
         for sid, q in self._sink_qs.items():
             out[f"sink[{sid}]"] = q.puts_dropped
         return out
+
+    def _record_queue_metrics(self) -> None:
+        metrics = getattr(self, "metrics", None)
+        if metrics is None:
+            return
+        metrics.set_queue_depth("frame", "all", self._frame_q.qsize())
+        metrics.set_queue_dropped_total("frame", "all", self._frame_q.puts_dropped)
+        metrics.set_queue_depth("candidate", "all", self._candidate_q.qsize())
+        metrics.set_queue_dropped_total("candidate", "all", self._candidate_q.puts_dropped)
+        for sid, q in self._sink_qs.items():
+            metrics.set_queue_depth("sink", sid, q.qsize())
+            metrics.set_queue_dropped_total("sink", sid, q.puts_dropped)
 
     @staticmethod
     def _log_drop_deltas(prev: dict[str, int], cur: dict[str, int]) -> None:

--- a/vrs/multistream/workers.py
+++ b/vrs/multistream/workers.py
@@ -17,10 +17,12 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from ..observability import NullVRSMetrics
 from ..policy import WatchPolicy
 from ..schemas import CandidateAlert, Detection, Frame, VerifiedAlert
 from .queues import BoundedQueue
@@ -111,6 +113,7 @@ class DetectorWorker(threading.Thread):
         verifier_cfg: dict | None = None,
         tracker_cfg: dict | None = None,
         target_fps: float = 4.0,
+        metrics: Any | None = None,
     ):
         super().__init__(name="detector", daemon=True)
         self.detector = detector
@@ -121,6 +124,7 @@ class DetectorWorker(threading.Thread):
         self.stop_event = stop_event
         self.batch_size = int(batch_size)
         self.batch_timeout = max(batch_timeout_ms, 1) / 1000.0
+        self.metrics = metrics or NullVRSMetrics()
 
         from ..triage import EventStateQueue, build_tracker  # lazy — keep workers import-light
 
@@ -160,11 +164,14 @@ class DetectorWorker(threading.Thread):
 
             # --- batched YOLOE inference ---
             frames = [m.frame for m in msgs]
+            detector_t0 = time.perf_counter()
             try:
                 all_dets = self.detector.batch(frames)
             except Exception as e:
                 logger.warning("detector batch failed: %s", e)
                 continue
+            finally:
+                self.metrics.observe_detector_latency(time.perf_counter() - detector_t0)
 
             # --- per-stream tracking + event-state + sink fanout ---
             for msg, dets in zip(msgs, all_dets, strict=True):
@@ -182,6 +189,7 @@ class DetectorWorker(threading.Thread):
                     continue
                 candidates = es.step(msg.frame, dets)
                 for cand in candidates:
+                    self.metrics.inc_candidates(sid, cand.class_name)
                     self.candidate_q.put(_CandidateMsg(stream_id=sid, alert=cand))
 
 
@@ -198,6 +206,8 @@ class VerifierWorker(threading.Thread):
         sink_queues: dict[str, BoundedQueue],
         stop_event: threading.Event,
         calibrator: Any | None = None,
+        metrics: Any | None = None,
+        verifier_backend: str = "disabled",
     ):
         super().__init__(name="verifier", daemon=True)
         self.verifier = verifier
@@ -205,6 +215,8 @@ class VerifierWorker(threading.Thread):
         self.sink_queues = sink_queues
         self.stop_event = stop_event
         self.calibrator = calibrator
+        self.metrics = metrics or NullVRSMetrics()
+        self.verifier_backend = verifier_backend
 
     def run(self) -> None:
         while not self.stop_event.is_set():
@@ -216,7 +228,14 @@ class VerifierWorker(threading.Thread):
                 break
 
             if self.verifier is not None:
-                verified = self.verifier.verify(msg.alert)
+                verifier_t0 = time.perf_counter()
+                try:
+                    verified = self.verifier.verify(msg.alert)
+                except Exception:
+                    self.metrics.inc_verifier_errors(self.verifier_backend)
+                    raise
+                finally:
+                    self.metrics.observe_verifier_latency(time.perf_counter() - verifier_t0)
             else:
                 verified = VerifiedAlert(
                     candidate=msg.alert,
@@ -225,6 +244,8 @@ class VerifierWorker(threading.Thread):
                     false_negative_class=None,
                     rationale="verifier disabled",
                 )
+            verdict = "true_alert" if verified.true_alert else "false_alert"
+            self.metrics.inc_verified_alerts(msg.stream_id, verified.candidate.class_name, verdict)
 
             sink_q = self.sink_queues.get(msg.stream_id)
             if sink_q is not None:
@@ -275,6 +296,7 @@ class SinkWorker(threading.Thread):
         thumbnail_ext: str = "jpg",
         thumbnail_quality: int = 90,
         privacy_cfg: dict | None = None,
+        metrics: Any | None = None,
     ):
         super().__init__(name=f"sink[{stream_id}]", daemon=True)
         self.stream_id = stream_id
@@ -291,6 +313,7 @@ class SinkWorker(threading.Thread):
         self.q = sink_q
         self.stop_event = stop_event
         self.privacy_cfg = privacy_cfg or {}
+        self.metrics = metrics or NullVRSMetrics()
 
     def run(self) -> None:
         # Import each sink directly (not via the package __init__) so an
@@ -353,6 +376,7 @@ class SinkWorker(threading.Thread):
                             if annotator is not None:
                                 annotator.note_alert(msg.verified)
                     except Exception as e:
+                        self.metrics.inc_sink_write_errors(self.stream_id)
                         logger.warning(
                             "sink[%s] write failed for %s: %s",
                             self.stream_id,

--- a/vrs/observability/__init__.py
+++ b/vrs/observability/__init__.py
@@ -1,0 +1,15 @@
+from .metrics import (
+    MetricsConfig,
+    MetricsRegistry,
+    NullVRSMetrics,
+    VRSMetrics,
+    build_metrics,
+)
+
+__all__ = [
+    "MetricsConfig",
+    "MetricsRegistry",
+    "NullVRSMetrics",
+    "VRSMetrics",
+    "build_metrics",
+]

--- a/vrs/observability/metrics.py
+++ b/vrs/observability/metrics.py
@@ -1,0 +1,440 @@
+"""Prometheus-compatible runtime metrics for VRS.
+
+The implementation intentionally uses only the Python standard library. VRS
+can expose a scrape endpoint on appliances without adding another runtime
+dependency, and tests can exercise metric behavior without importing GPU
+libraries.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import threading
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+_METRIC_NAME_RE = re.compile(r"^[a-zA-Z_:][a-zA-Z0-9_:]*$")
+_LABEL_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+_DEFAULT_LATENCY_BUCKETS = (
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    30.0,
+    60.0,
+)
+
+
+def _check_metric_name(name: str) -> None:
+    if not _METRIC_NAME_RE.match(name):
+        raise ValueError(f"invalid metric name: {name!r}")
+
+
+def _check_label_names(labelnames: tuple[str, ...]) -> None:
+    for label in labelnames:
+        if not _LABEL_NAME_RE.match(label):
+            raise ValueError(f"invalid label name: {label!r}")
+
+
+def _escape_label_value(value: Any) -> str:
+    text = str(value)
+    return text.replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
+
+def _format_number(value: float) -> str:
+    if math.isinf(value):
+        return "+Inf" if value > 0 else "-Inf"
+    return f"{value:g}"
+
+
+def _format_labels(labels: dict[str, str]) -> str:
+    if not labels:
+        return ""
+    parts = [f'{k}="{_escape_label_value(v)}"' for k, v in labels.items()]
+    return "{" + ",".join(parts) + "}"
+
+
+class _Metric:
+    def __init__(self, name: str, help_text: str, kind: str, labelnames: tuple[str, ...]):
+        _check_metric_name(name)
+        _check_label_names(labelnames)
+        self.name = name
+        self.help_text = help_text
+        self.kind = kind
+        self.labelnames = labelnames
+        self._lock = threading.RLock()
+
+    def _labels_key(self, labels: dict[str, str]) -> tuple[str, ...]:
+        expected = set(self.labelnames)
+        actual = set(labels)
+        if expected != actual:
+            raise ValueError(
+                f"{self.name}: expected labels {sorted(expected)}, got {sorted(actual)}"
+            )
+        return tuple(str(labels[name]) for name in self.labelnames)
+
+    def render(self) -> list[str]:
+        raise NotImplementedError
+
+
+class _Counter(_Metric):
+    def __init__(self, name: str, help_text: str, labelnames: tuple[str, ...]):
+        super().__init__(name, help_text, "counter", labelnames)
+        self._values: dict[tuple[str, ...], float] = {}
+
+    def inc(self, amount: float = 1.0, **labels: str) -> None:
+        if amount < 0:
+            raise ValueError("counter increment must be non-negative")
+        with self._lock:
+            key = self._labels_key(labels)
+            self._values[key] = self._values.get(key, 0.0) + float(amount)
+
+    def set_total(self, value: float, **labels: str) -> None:
+        if value < 0:
+            raise ValueError("counter total must be non-negative")
+        with self._lock:
+            key = self._labels_key(labels)
+            self._values[key] = max(self._values.get(key, 0.0), float(value))
+
+    def render(self) -> list[str]:
+        with self._lock:
+            lines = []
+            for key, value in sorted(self._values.items()):
+                labels = dict(zip(self.labelnames, key, strict=True))
+                lines.append(f"{self.name}{_format_labels(labels)} {_format_number(value)}")
+            return lines
+
+
+class _Gauge(_Metric):
+    def __init__(self, name: str, help_text: str, labelnames: tuple[str, ...]):
+        super().__init__(name, help_text, "gauge", labelnames)
+        self._values: dict[tuple[str, ...], float] = {}
+
+    def set(self, value: float, **labels: str) -> None:
+        with self._lock:
+            self._values[self._labels_key(labels)] = float(value)
+
+    def render(self) -> list[str]:
+        with self._lock:
+            lines = []
+            for key, value in sorted(self._values.items()):
+                labels = dict(zip(self.labelnames, key, strict=True))
+                lines.append(f"{self.name}{_format_labels(labels)} {_format_number(value)}")
+            return lines
+
+
+class _Histogram(_Metric):
+    def __init__(
+        self,
+        name: str,
+        help_text: str,
+        labelnames: tuple[str, ...],
+        buckets: tuple[float, ...],
+    ):
+        super().__init__(name, help_text, "histogram", labelnames)
+        self._buckets = tuple(sorted(float(b) for b in buckets))
+        self._values: dict[tuple[str, ...], tuple[list[int], int, float]] = {}
+
+    def observe(self, value: float, **labels: str) -> None:
+        with self._lock:
+            key = self._labels_key(labels)
+            counts, total_count, total_sum = self._values.get(
+                key, ([0 for _ in self._buckets], 0, 0.0)
+            )
+            value = float(value)
+            for i, bound in enumerate(self._buckets):
+                if value <= bound:
+                    counts[i] += 1
+            self._values[key] = (counts, total_count + 1, total_sum + value)
+
+    def render(self) -> list[str]:
+        with self._lock:
+            lines = []
+            for key, (counts, total_count, total_sum) in sorted(self._values.items()):
+                base_labels = dict(zip(self.labelnames, key, strict=True))
+                for bound, count in zip(self._buckets, counts, strict=True):
+                    labels = {**base_labels, "le": _format_number(bound)}
+                    lines.append(
+                        f"{self.name}_bucket{_format_labels(labels)} {_format_number(count)}"
+                    )
+                labels = {**base_labels, "le": "+Inf"}
+                lines.append(
+                    f"{self.name}_bucket{_format_labels(labels)} {_format_number(total_count)}"
+                )
+                lines.append(
+                    f"{self.name}_count{_format_labels(base_labels)} {_format_number(total_count)}"
+                )
+                lines.append(
+                    f"{self.name}_sum{_format_labels(base_labels)} {_format_number(total_sum)}"
+                )
+            return lines
+
+
+class MetricsRegistry:
+    """Small thread-safe registry that renders Prometheus text exposition."""
+
+    def __init__(self):
+        self._metrics: dict[str, _Metric] = {}
+        self._lock = threading.RLock()
+
+    def counter(
+        self,
+        name: str,
+        help_text: str,
+        labelnames: tuple[str, ...] = (),
+    ) -> _Counter:
+        return self._register(_Counter(name, help_text, labelnames), _Counter)
+
+    def gauge(
+        self,
+        name: str,
+        help_text: str,
+        labelnames: tuple[str, ...] = (),
+    ) -> _Gauge:
+        return self._register(_Gauge(name, help_text, labelnames), _Gauge)
+
+    def histogram(
+        self,
+        name: str,
+        help_text: str,
+        labelnames: tuple[str, ...] = (),
+        buckets: tuple[float, ...] = _DEFAULT_LATENCY_BUCKETS,
+    ) -> _Histogram:
+        return self._register(_Histogram(name, help_text, labelnames, buckets), _Histogram)
+
+    def _register(self, metric: _Metric, expected_type: type) -> Any:
+        with self._lock:
+            existing = self._metrics.get(metric.name)
+            if existing is not None:
+                if not isinstance(existing, expected_type):
+                    raise ValueError(f"metric already registered with another type: {metric.name}")
+                if existing.labelnames != metric.labelnames:
+                    raise ValueError(
+                        f"metric already registered with different labels: {metric.name}"
+                    )
+                return existing
+            self._metrics[metric.name] = metric
+            return metric
+
+    def render(self) -> str:
+        with self._lock:
+            lines: list[str] = []
+            for metric in self._metrics.values():
+                lines.append(f"# HELP {metric.name} {metric.help_text}")
+                lines.append(f"# TYPE {metric.name} {metric.kind}")
+                lines.extend(metric.render())
+            return "\n".join(lines) + "\n"
+
+
+@dataclass(frozen=True)
+class MetricsConfig:
+    enabled: bool = False
+    host: str = "127.0.0.1"
+    port: int = 9108
+    path: str = "/metrics"
+
+    @classmethod
+    def from_app_config(cls, cfg: dict[str, Any]) -> MetricsConfig:
+        obs = cfg.get("observability") or {}
+        raw = obs.get("metrics") or {}
+        return cls(
+            enabled=bool(raw.get("enabled", False)),
+            host=str(raw.get("host", "127.0.0.1")),
+            port=int(raw.get("port", 9108)),
+            path=str(raw.get("path", "/metrics")),
+        )
+
+
+class MetricsServer:
+    def __init__(self, registry: MetricsRegistry, config: MetricsConfig):
+        self.registry = registry
+        self.config = config
+        self._httpd: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self._httpd is not None:
+            return
+        registry = self.registry
+        path = self.config.path
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                if self.path != path:
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                body = registry.render().encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format: str, *args: object) -> None:
+                return
+
+        self._httpd = ThreadingHTTPServer((self.config.host, self.config.port), Handler)
+        self._thread = threading.Thread(
+            target=self._httpd.serve_forever,
+            name="metrics-server",
+            daemon=True,
+        )
+        self._thread.start()
+
+    @property
+    def url(self) -> str | None:
+        if self._httpd is None:
+            return None
+        host, port = self._httpd.server_address
+        return f"http://{host}:{port}{self.config.path}"
+
+    def close(self) -> None:
+        if self._httpd is None:
+            return
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        self._httpd = None
+        self._thread = None
+
+
+class NullVRSMetrics:
+    enabled = False
+    registry: MetricsRegistry | None = None
+    url: str | None = None
+
+    def set_queue_depth(self, queue: str, stream_id: str, depth: int) -> None:
+        return
+
+    def set_queue_dropped_total(self, queue: str, stream_id: str, dropped: int) -> None:
+        return
+
+    def inc_candidates(self, stream_id: str, class_name: str, amount: int = 1) -> None:
+        return
+
+    def inc_verified_alerts(
+        self, stream_id: str, class_name: str, verdict: str, amount: int = 1
+    ) -> None:
+        return
+
+    def observe_detector_latency(self, seconds: float) -> None:
+        return
+
+    def observe_verifier_latency(self, seconds: float) -> None:
+        return
+
+    def inc_verifier_errors(self, backend: str, amount: int = 1) -> None:
+        return
+
+    def inc_sink_write_errors(self, stream_id: str, amount: int = 1) -> None:
+        return
+
+    def close(self) -> None:
+        return
+
+
+class VRSMetrics:
+    enabled = True
+
+    def __init__(
+        self, registry: MetricsRegistry | None = None, server: MetricsServer | None = None
+    ):
+        self.registry = registry or MetricsRegistry()
+        self._server = server
+        self.queue_depth = self.registry.gauge(
+            "vrs_queue_depth",
+            "Current VRS queue depth.",
+            ("queue", "stream_id"),
+        )
+        self.queue_dropped = self.registry.counter(
+            "vrs_queue_dropped_total",
+            "Total VRS queue items dropped by bounded queues.",
+            ("queue", "stream_id"),
+        )
+        self.candidates = self.registry.counter(
+            "vrs_candidates_total",
+            "Total detector candidates promoted for verification.",
+            ("stream_id", "class"),
+        )
+        self.verified_alerts = self.registry.counter(
+            "vrs_verified_alerts_total",
+            "Total verified alerts by verdict.",
+            ("stream_id", "class", "verdict"),
+        )
+        self.detector_latency = self.registry.histogram(
+            "vrs_detector_latency_seconds",
+            "Detector inference latency in seconds.",
+        )
+        self.verifier_latency = self.registry.histogram(
+            "vrs_verifier_latency_seconds",
+            "Verifier latency in seconds.",
+        )
+        self.verifier_errors = self.registry.counter(
+            "vrs_verifier_errors_total",
+            "Total verifier errors by backend.",
+            ("backend",),
+        )
+        self.sink_write_errors = self.registry.counter(
+            "vrs_sink_write_errors_total",
+            "Total sink write errors by stream.",
+            ("stream_id",),
+        )
+
+    @property
+    def url(self) -> str | None:
+        return self._server.url if self._server is not None else None
+
+    def set_queue_depth(self, queue: str, stream_id: str, depth: int) -> None:
+        self.queue_depth.set(float(depth), queue=queue, stream_id=stream_id)
+
+    def set_queue_dropped_total(self, queue: str, stream_id: str, dropped: int) -> None:
+        self.queue_dropped.set_total(float(dropped), queue=queue, stream_id=stream_id)
+
+    def inc_candidates(self, stream_id: str, class_name: str, amount: int = 1) -> None:
+        self.candidates.inc(float(amount), stream_id=stream_id, **{"class": class_name})
+
+    def inc_verified_alerts(
+        self, stream_id: str, class_name: str, verdict: str, amount: int = 1
+    ) -> None:
+        self.verified_alerts.inc(
+            float(amount), stream_id=stream_id, verdict=verdict, **{"class": class_name}
+        )
+
+    def observe_detector_latency(self, seconds: float) -> None:
+        self.detector_latency.observe(float(seconds))
+
+    def observe_verifier_latency(self, seconds: float) -> None:
+        self.verifier_latency.observe(float(seconds))
+
+    def inc_verifier_errors(self, backend: str, amount: int = 1) -> None:
+        self.verifier_errors.inc(float(amount), backend=backend)
+
+    def inc_sink_write_errors(self, stream_id: str, amount: int = 1) -> None:
+        self.sink_write_errors.inc(float(amount), stream_id=stream_id)
+
+    def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+
+
+def build_metrics(config: dict[str, Any]) -> VRSMetrics | NullVRSMetrics:
+    metrics_config = MetricsConfig.from_app_config(config)
+    if not metrics_config.enabled:
+        return NullVRSMetrics()
+
+    registry = MetricsRegistry()
+    server = MetricsServer(registry, metrics_config)
+    metrics = VRSMetrics(registry=registry, server=server)
+    server.start()
+    return metrics

--- a/vrs/pipeline.py
+++ b/vrs/pipeline.py
@@ -7,6 +7,7 @@ module so this file stays short.
 from __future__ import annotations
 
 import logging
+import time
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,7 @@ import yaml
 
 from .calibration import build_calibrator
 from .ingest import StreamReader
+from .observability import build_metrics
 from .policy import WatchPolicy, load_watch_policy
 from .privacy import build_face_detector
 from .runtime import VLMConfig, build_vlm_backend
@@ -70,11 +72,13 @@ class VRSPipeline:
         self.policy = policy
         self.out_dir = Path(out_dir)
         self.out_dir.mkdir(parents=True, exist_ok=True)
+        self.metrics = build_metrics(config)
 
         det_cfg = config["detector"]
         ing_cfg = config["ingest"]
         es_cfg = config["event_state"]
         ver_cfg = config["verifier"]
+        self._verifier_backend = str(ver_cfg.get("backend", "transformers"))
 
         # --- fast path ---
         self.detector = build_detector(
@@ -166,13 +170,27 @@ class VRSPipeline:
         try:
             with JsonlSink(jsonl_path) as jsonl:
                 for frame in reader:
-                    detections = self.detector(frame)
+                    detector_t0 = time.perf_counter()
+                    try:
+                        detections = self.detector(frame)
+                    finally:
+                        self.metrics.observe_detector_latency(time.perf_counter() - detector_t0)
                     detections = self.tracker.update(detections, frame.index)
                     candidates = self.event_state.step(frame, detections)
 
                     for cand in candidates:
+                        self.metrics.inc_candidates("default", cand.class_name)
                         if self.verifier is not None:
-                            verified = self.verifier.verify(cand)
+                            verifier_t0 = time.perf_counter()
+                            try:
+                                verified = self.verifier.verify(cand)
+                            except Exception:
+                                self.metrics.inc_verifier_errors(self._verifier_backend)
+                                raise
+                            finally:
+                                self.metrics.observe_verifier_latency(
+                                    time.perf_counter() - verifier_t0
+                                )
                         else:
                             verified = VerifiedAlert(
                                 candidate=cand,
@@ -181,10 +199,15 @@ class VRSPipeline:
                                 false_negative_class=None,
                                 rationale="verifier disabled",
                             )
+                        verdict = "true_alert" if verified.true_alert else "false_alert"
+                        self.metrics.inc_verified_alerts(
+                            "default", verified.candidate.class_name, verdict
+                        )
                         if thumbnail_sink is not None:
                             try:
                                 thumbnail_sink.write(verified)
                             except Exception as e:
+                                self.metrics.inc_sink_write_errors("default")
                                 logger.warning("thumbnail write failed: %s", e)
                         jsonl.write(verified)
                         if annotator is not None:
@@ -200,6 +223,7 @@ class VRSPipeline:
                 annotator.close()
             if self.calibrator is not None:
                 self.calibrator.close()
+            self.metrics.close()
 
     @staticmethod
     def _log(v: VerifiedAlert) -> None:


### PR DESCRIPTION
## Summary
- add a standard-library Prometheus-compatible metrics registry and /metrics HTTP endpoint behind observability.metrics.enabled
- record VRS queue depth/drop totals, candidates, verified alert verdicts, detector/verifier latency, verifier errors, and sink write errors
- document scrape configuration and add CPU-only metrics tests

## Validation
- python -m ruff check .
- python -m ruff format --check .
- python -m pytest -q