### PR TITLE
[codex] feat(policy): add scenario policy packs

### DIFF
--- a/configs/policies/examples/elderly_care.yaml
+++ b/configs/policies/examples/elderly_care.yaml
@@ -1,0 +1,68 @@
+policy_id: elderly_care_v1
+policy_version: 1
+description: Elderly-care fall verification semantics.
+
+scenarios:
+  - id: elderly_room_fall
+    event_class: falldown
+    detector_labels:
+      - person lying on the ground
+      - fallen person
+      - collapsed person
+    prompt_template: verifier_base.md
+    context_window_s: 10
+    min_detector_confidence: 0.3
+
+    normal_conditions:
+      - person resting on a bed, sofa, or recliner
+      - caregiver kneeling beside a resident
+      - resident exercising on a floor mat with normal movement
+
+    abnormal_conditions:
+      - person lying on the floor away from furniture
+      - abrupt transition from standing or walking to the floor
+      - person motionless or struggling to get up after falling
+
+    false_positive_hints:
+      - bed or sofa use
+      - stretching on mat
+      - caregiver kneeling
+
+    true_positive_hints:
+      - body on floor in walkway
+      - unusual sprawled posture
+      - no recovery across sampled frames
+
+    required_evidence:
+      - person location relative to floor and furniture
+      - posture
+      - motion before and after peak frame
+      - whether another person is assisting
+
+    uncertain_when:
+      - the person is heavily occluded
+      - only one frame shows the person on the floor
+      - low light prevents posture assessment
+
+    verifier:
+      enabled: true
+      require_json: true
+      decision_labels:
+        - true_alert
+        - false_positive
+        - uncertain
+
+    severity:
+      true_alert: high
+      uncertain: warning
+
+    recommended_action:
+      true_alert: notify_caregiver
+      uncertain: request_review
+
+    zones:
+      include:
+        - resident_room
+        - hallway
+      exclude:
+        - bed_area

--- a/configs/policies/examples/factory_fire_safety.yaml
+++ b/configs/policies/examples/factory_fire_safety.yaml
@@ -1,0 +1,128 @@
+policy_id: factory_fire_safety_v1
+policy_version: 1
+description: Factory fire and smoke verifier semantics.
+
+scenarios:
+  - id: factory_smoke_vs_steam
+    event_class: smoke
+    detector_labels:
+      - smoke
+      - smoke cloud
+      - billowing smoke
+    prompt_template: verifier_base.md
+    context_window_s: 12
+    min_detector_confidence: 0.35
+
+    normal_conditions:
+      - white steam from configured vent areas
+      - short-lived vapor plume near cooling equipment
+      - temporary dust cloud near loading dock
+
+    abnormal_conditions:
+      - dark smoke accumulating near ceiling
+      - smoke from machine housing
+      - smoke persisting across multiple sampled frames
+
+    false_positive_hints:
+      - steam vent
+      - dust cloud
+      - exhaust plume
+
+    true_positive_hints:
+      - dark smoke accumulating near ceiling
+      - smoke from machine housing
+      - smoke with visible flame nearby
+
+    required_evidence:
+      - source location
+      - color and density
+      - persistence across frames
+      - spread direction
+
+    uncertain_when:
+      - source is outside the visible scene
+      - smoke-like region appears in only one sampled frame
+      - image is too dark or blurry
+
+    verifier:
+      enabled: true
+      require_json: true
+      decision_labels:
+        - true_alert
+        - false_positive
+        - uncertain
+
+    severity:
+      true_alert: critical
+      uncertain: warning
+
+    recommended_action:
+      true_alert: notify_operator
+      uncertain: request_review
+
+    zones:
+      include:
+        - production_floor
+      exclude:
+        - steam_vent_area
+
+  - id: factory_flame_vs_welding
+    event_class: fire
+    detector_labels:
+      - fire
+      - open flame
+      - burning object
+    prompt_template: verifier_base.md
+    context_window_s: 8
+    min_detector_confidence: 0.4
+
+    normal_conditions:
+      - bright welding arc inside a marked welding bay
+      - controlled torch flame in approved hot-work area
+      - orange warning beacon or reflection on machinery
+
+    abnormal_conditions:
+      - flame outside an approved hot-work area
+      - flame spreading from materials or machine housing
+      - flame with smoke or visible charring nearby
+
+    false_positive_hints:
+      - welding arc
+      - warning beacon
+      - sun reflection
+
+    true_positive_hints:
+      - uncontrolled flame
+      - burning material
+      - smoke rising from ignition source
+
+    required_evidence:
+      - flame source
+      - nearby material or equipment
+      - whether the location is an approved hot-work zone
+
+    uncertain_when:
+      - the bright source is saturated or occluded
+      - the source location cannot be tied to a zone
+
+    verifier:
+      enabled: true
+      require_json: true
+      decision_labels:
+        - true_alert
+        - false_positive
+        - uncertain
+
+    severity:
+      true_alert: critical
+      uncertain: warning
+
+    recommended_action:
+      true_alert: notify_operator
+      uncertain: request_review
+
+    zones:
+      include:
+        - production_floor
+      exclude:
+        - welding_bay

--- a/prompts/templates/verifier_base.md
+++ b/prompts/templates/verifier_base.md
@@ -1,0 +1,48 @@
+You are verifying a visual event candidate for a CCTV safety system.
+
+Policy: {{ policy_id }} v{{ policy_version }}
+Scenario: {{ scenario_id }}
+Event class: {{ event_class }}
+Detector labels: {{ detector_labels }}
+
+Candidate metadata:
+- detector label: {{ detector_label }}
+- detector confidence: {{ detector_confidence }}
+- stream: {{ stream_id }}
+- site: {{ site_id }}
+- camera: {{ camera_id }}
+- zones: {{ zone_ids }}
+- track id: {{ track_id }}
+- time range: {{ start_pts_s }}s to {{ peak_pts_s }}s
+- sampled keyframes: {{ keyframe_pts }}
+- scenario context window: {{ context_window_s }}s
+
+Normal or benign conditions:
+{{ normal_conditions }}
+
+Abnormal conditions that support a true alert:
+{{ abnormal_conditions }}
+
+False-positive hints:
+{{ false_positive_hints }}
+
+True-positive hints:
+{{ true_positive_hints }}
+
+Required evidence to cite:
+{{ required_evidence }}
+
+Return uncertain when:
+{{ uncertain_when }}
+
+Severity mapping:
+{{ severity_mapping }}
+
+Recommended action mapping:
+{{ recommended_action_mapping }}
+
+Decision labels: {{ verifier_output_labels }}
+
+Use the frames in order. Decide whether this candidate matches the scenario-specific event semantics, not just whether the detector label appears plausible.
+
+{{ json_output_requirements }}

--- a/prompts/templates/verifier_json_output.md
+++ b/prompts/templates/verifier_json_output.md
@@ -1,0 +1,15 @@
+Reply with exactly one JSON object and no prose or code fence.
+
+Required JSON fields:
+- verdict: one of the scenario decision labels
+- confidence: number in [0.0, 1.0]
+- event_class: event class being verified
+- scenario_id: matched scenario id
+- policy_id: policy pack id
+- policy_version: policy pack version
+- severity: severity derived from the scenario severity mapping
+- evidence: array of concise observations supporting the verdict
+- false_positive_reason: string or null
+- recommended_action: action derived from the scenario action mapping
+
+Use null for false_positive_reason unless the verdict is false_positive. Evidence must cite visible facts such as source location, persistence, movement, color, density, posture, occlusion, or frame quality when those fields are relevant to the scenario.

--- a/tests/test_scenario_policy.py
+++ b/tests/test_scenario_policy.py
@@ -1,0 +1,170 @@
+"""CPU-only tests for scenario verifier policy packs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from vrs.policy import (
+    CandidatePolicyMetadata,
+    ScenarioPolicyRouter,
+    ScenarioPromptRenderer,
+    load_policy_pack,
+)
+from vrs.schemas import CandidateAlert, Detection
+
+ROOT = Path(__file__).parent.parent
+FACTORY_POLICY = ROOT / "configs/policies/examples/factory_fire_safety.yaml"
+TEMPLATE_DIR = ROOT / "prompts/templates"
+
+
+def test_load_scenario_policy_pack_from_yaml():
+    pack = load_policy_pack(FACTORY_POLICY)
+
+    assert pack.policy_id == "factory_fire_safety_v1"
+    assert pack.policy_version == 1
+    scenario = pack.get_scenario("factory_smoke_vs_steam")
+    assert scenario is not None
+    assert scenario.event_class == "smoke"
+    assert scenario.detector_labels == ("smoke", "smoke cloud", "billowing smoke")
+    assert scenario.context_window_s == pytest.approx(12.0)
+    assert scenario.min_detector_confidence == pytest.approx(0.35)
+    assert "white steam from configured vent areas" in scenario.normal_conditions
+    assert scenario.zones.include == ("production_floor",)
+    assert scenario.zones.exclude == ("steam_vent_area",)
+    assert scenario.verifier.require_json is True
+    assert scenario.severity_for("true_alert") == "critical"
+    assert scenario.recommended_action_for("uncertain") == "request_review"
+
+
+def test_policy_loader_rejects_duplicate_scenario_ids(tmp_path: Path):
+    bad = tmp_path / "bad_policy.yaml"
+    bad.write_text(
+        "policy_id: bad\n"
+        "policy_version: 1\n"
+        "scenarios:\n"
+        "  - id: duplicate\n"
+        "    event_class: smoke\n"
+        "    detector_labels: [smoke]\n"
+        "    prompt_template: verifier_base.md\n"
+        "  - id: duplicate\n"
+        "    event_class: fire\n"
+        "    detector_labels: [fire]\n"
+        "    prompt_template: verifier_base.md\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate scenario id"):
+        load_policy_pack(bad)
+
+
+def test_router_matches_event_label_confidence_and_zone():
+    pack = load_policy_pack(FACTORY_POLICY)
+    router = ScenarioPolicyRouter(pack)
+
+    match = router.match(
+        CandidatePolicyMetadata(
+            event_class="smoke",
+            detector_label="smoke cloud",
+            detector_confidence=0.71,
+            zone_ids=("production_floor",),
+        )
+    )
+
+    assert match is not None
+    assert match.policy_pack is pack
+    assert match.scenario.id == "factory_smoke_vs_steam"
+
+
+def test_router_rejects_excluded_zone_and_low_confidence():
+    pack = load_policy_pack(FACTORY_POLICY)
+    router = ScenarioPolicyRouter(pack)
+
+    assert (
+        router.match(
+            {
+                "event_class": "smoke",
+                "detector_label": "smoke",
+                "detector_confidence": 0.34,
+                "zone_ids": ["production_floor"],
+            }
+        )
+        is None
+    )
+    assert (
+        router.match(
+            {
+                "event_class": "smoke",
+                "detector_label": "smoke",
+                "detector_confidence": 0.9,
+                "zone_ids": ["production_floor", "steam_vent_area"],
+            }
+        )
+        is None
+    )
+
+
+def test_router_normalizes_candidate_alert_metadata():
+    pack = load_policy_pack(FACTORY_POLICY)
+    router = ScenarioPolicyRouter(pack)
+    alert = CandidateAlert(
+        class_name="smoke",
+        severity="high",
+        start_pts_s=1.0,
+        peak_pts_s=3.0,
+        peak_frame_index=12,
+        peak_detections=[
+            Detection(
+                class_name="smoke",
+                score=0.8,
+                xyxy=(1.0, 2.0, 10.0, 20.0),
+                raw_label="smoke cloud",
+            )
+        ],
+        keyframes=[np.zeros((4, 4, 3), dtype=np.uint8)],
+        keyframe_pts=[1.0, 2.0, 3.0],
+    )
+
+    meta = CandidatePolicyMetadata.from_candidate_alert(alert, zone_ids=("production_floor",))
+    match = router.match(meta)
+
+    assert meta.detector_confidence == pytest.approx(0.8)
+    assert meta.detector_label == "smoke cloud"
+    assert meta.keyframe_pts == (1.0, 2.0, 3.0)
+    assert match is not None
+    assert match.scenario.id == "factory_smoke_vs_steam"
+
+
+def test_prompt_renderer_includes_policy_fields_and_json_requirements():
+    pack = load_policy_pack(FACTORY_POLICY)
+    scenario = pack.get_scenario("factory_smoke_vs_steam")
+    assert scenario is not None
+    rendered = ScenarioPromptRenderer(TEMPLATE_DIR).render(
+        pack,
+        scenario,
+        CandidatePolicyMetadata(
+            event_class="smoke",
+            detector_label="smoke cloud",
+            detector_confidence=0.82,
+            zone_ids=("production_floor",),
+            stream_id="stream-1",
+            camera_id="cam-7",
+            site_id="factory-a",
+            start_pts_s=10.0,
+            peak_pts_s=12.0,
+            keyframe_pts=(10.0, 11.0, 12.0),
+        ),
+    )
+
+    assert "Policy: factory_fire_safety_v1 v1" in rendered
+    assert "Scenario: factory_smoke_vs_steam" in rendered
+    assert "white steam from configured vent areas" in rendered
+    assert "dark smoke accumulating near ceiling" in rendered
+    assert "source location" in rendered
+    assert "source is outside the visible scene" in rendered
+    assert "Reply with exactly one JSON object" in rendered
+    assert "verdict" in rendered
+    assert "policy_version" in rendered
+    assert "recommended_action" in rendered

--- a/vrs/policy/__init__.py
+++ b/vrs/policy/__init__.py
@@ -1,3 +1,21 @@
+from .loader import load_policy_pack, load_policy_packs
+from .prompt_renderer import ScenarioPromptRenderer
+from .router import CandidatePolicyMetadata, ScenarioPolicyMatch, ScenarioPolicyRouter
+from .schema import PolicyPack, ScenarioPolicy, VerifierPolicy, ZoneRules
 from .watch_policy import WatchItem, WatchPolicy, load_watch_policy
 
-__all__ = ["WatchItem", "WatchPolicy", "load_watch_policy"]
+__all__ = [
+    "CandidatePolicyMetadata",
+    "PolicyPack",
+    "ScenarioPolicy",
+    "ScenarioPolicyMatch",
+    "ScenarioPolicyRouter",
+    "ScenarioPromptRenderer",
+    "VerifierPolicy",
+    "WatchItem",
+    "WatchPolicy",
+    "ZoneRules",
+    "load_policy_pack",
+    "load_policy_packs",
+    "load_watch_policy",
+]

--- a/vrs/policy/loader.py
+++ b/vrs/policy/loader.py
@@ -1,0 +1,27 @@
+"""YAML loading helpers for scenario verifier policy packs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from .schema import PolicyPack
+
+
+def load_policy_pack(path: str | Path) -> PolicyPack:
+    """Load a scenario verifier policy pack from YAML."""
+
+    policy_path = Path(path)
+    with policy_path.open(encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+    try:
+        return PolicyPack.from_mapping(raw)
+    except ValueError as e:
+        raise ValueError(f"{policy_path}: {e}") from e
+
+
+def load_policy_packs(paths: list[str | Path] | tuple[str | Path, ...]) -> list[PolicyPack]:
+    """Load multiple policy packs in caller-provided priority order."""
+
+    return [load_policy_pack(path) for path in paths]

--- a/vrs/policy/prompt_renderer.py
+++ b/vrs/policy/prompt_renderer.py
@@ -1,0 +1,108 @@
+"""Render verifier prompts from structured scenario policies."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from .router import CandidatePolicyMetadata, normalize_candidate_metadata
+from .schema import PolicyPack, ScenarioPolicy
+
+_TOKEN_RE = re.compile(r"{{\s*([a-zA-Z0-9_]+)\s*}}")
+
+
+class ScenarioPromptRenderer:
+    """Small Markdown-template renderer for verifier policy prompts.
+
+    Templates use ``{{ token }}`` placeholders.  This intentionally stays simple
+    so policy packs remain structured YAML, while prompt wording lives in a few
+    reusable Markdown templates.
+    """
+
+    def __init__(self, template_dir: str | Path):
+        self.template_dir = Path(template_dir)
+
+    def render(
+        self,
+        policy_pack: PolicyPack,
+        scenario: ScenarioPolicy,
+        candidate: CandidatePolicyMetadata | dict[str, Any],
+    ) -> str:
+        meta = normalize_candidate_metadata(candidate)
+        base = self._load_template(scenario.prompt_template)
+        context = self._context(policy_pack, scenario, meta)
+        rendered = self._render_tokens(base, context)
+        if scenario.verifier.require_json and "{{ json_output_requirements }}" not in base:
+            rendered = rendered.rstrip() + "\n\n" + context["json_output_requirements"]
+        return rendered.rstrip() + "\n"
+
+    def _load_template(self, name: str) -> str:
+        path = self.template_dir / name
+        if not path.is_file():
+            raise FileNotFoundError(f"prompt template not found: {path}")
+        return path.read_text(encoding="utf-8")
+
+    def _context(
+        self,
+        policy_pack: PolicyPack,
+        scenario: ScenarioPolicy,
+        candidate: CandidatePolicyMetadata,
+    ) -> dict[str, str]:
+        severity_items = [f"{label}: {value}" for label, value in scenario.severity.items()]
+        action_items = [f"{label}: {value}" for label, value in scenario.recommended_action.items()]
+        return {
+            "policy_id": policy_pack.policy_id,
+            "policy_version": str(policy_pack.policy_version),
+            "scenario_id": scenario.id,
+            "event_class": scenario.event_class,
+            "detector_labels": _inline_list(scenario.detector_labels),
+            "detector_label": candidate.detector_label or "(unknown)",
+            "detector_confidence": _format_float(candidate.detector_confidence),
+            "context_window_s": _format_float(scenario.context_window_s),
+            "start_pts_s": _format_float(candidate.start_pts_s),
+            "peak_pts_s": _format_float(candidate.peak_pts_s),
+            "keyframe_pts": _inline_list(f"{pts:.2f}s" for pts in candidate.keyframe_pts),
+            "zone_ids": _inline_list(candidate.zone_ids),
+            "track_id": str(candidate.track_id) if candidate.track_id is not None else "(none)",
+            "stream_id": candidate.stream_id or "(unknown)",
+            "camera_id": candidate.camera_id or "(unknown)",
+            "site_id": candidate.site_id or "(unknown)",
+            "normal_conditions": _bullet_list(scenario.normal_conditions),
+            "abnormal_conditions": _bullet_list(scenario.abnormal_conditions),
+            "false_positive_hints": _bullet_list(scenario.false_positive_hints),
+            "true_positive_hints": _bullet_list(scenario.true_positive_hints),
+            "required_evidence": _bullet_list(scenario.required_evidence),
+            "uncertain_when": _bullet_list(scenario.uncertain_when),
+            "severity_mapping": _bullet_list(severity_items),
+            "recommended_action_mapping": _bullet_list(action_items),
+            "verifier_output_labels": _inline_list(scenario.verifier.decision_labels),
+            "json_output_requirements": self._load_template("verifier_json_output.md").rstrip(),
+        }
+
+    @staticmethod
+    def _render_tokens(template: str, context: dict[str, str]) -> str:
+        def replace(match: re.Match[str]) -> str:
+            token = match.group(1)
+            if token not in context:
+                raise KeyError(f"unknown prompt template token: {token}")
+            return context[token]
+
+        return _TOKEN_RE.sub(replace, template)
+
+
+def _bullet_list(items: list[str] | tuple[str, ...]) -> str:
+    if not items:
+        return "- (none specified)"
+    return "\n".join(f"- {item}" for item in items)
+
+
+def _inline_list(items) -> str:
+    values = [str(item) for item in items if str(item)]
+    return ", ".join(values) if values else "(none)"
+
+
+def _format_float(value: float | None) -> str:
+    if value is None:
+        return "(unknown)"
+    return f"{float(value):.2f}"

--- a/vrs/policy/router.py
+++ b/vrs/policy/router.py
@@ -1,0 +1,162 @@
+"""Scenario policy routing for verifier candidates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..schemas import CandidateAlert
+from .schema import PolicyPack, ScenarioPolicy
+
+
+@dataclass(frozen=True)
+class CandidatePolicyMetadata:
+    """Normalized candidate fields used for scenario policy matching."""
+
+    event_class: str
+    detector_label: str | None = None
+    detector_confidence: float | None = None
+    zone_ids: tuple[str, ...] = ()
+    stream_id: str | None = None
+    camera_id: str | None = None
+    site_id: str | None = None
+    track_id: int | None = None
+    start_pts_s: float | None = None
+    peak_pts_s: float | None = None
+    keyframe_pts: tuple[float, ...] = ()
+    extra: dict[str, Any] | None = None
+
+    @classmethod
+    def from_candidate_alert(
+        cls,
+        candidate: CandidateAlert,
+        *,
+        zone_ids: list[str] | tuple[str, ...] | None = None,
+        stream_id: str | None = None,
+        camera_id: str | None = None,
+        site_id: str | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> CandidatePolicyMetadata:
+        peak = max((det.score for det in candidate.peak_detections), default=None)
+        raw_label = next(
+            (det.raw_label for det in candidate.peak_detections if det.raw_label),
+            None,
+        )
+        return cls(
+            event_class=candidate.class_name,
+            detector_label=raw_label,
+            detector_confidence=peak,
+            zone_ids=tuple(zone_ids or ()),
+            stream_id=stream_id,
+            camera_id=camera_id,
+            site_id=site_id,
+            track_id=candidate.track_id,
+            start_pts_s=candidate.start_pts_s,
+            peak_pts_s=candidate.peak_pts_s,
+            keyframe_pts=tuple(candidate.keyframe_pts),
+            extra=dict(extra or {}),
+        )
+
+    @classmethod
+    def from_mapping(cls, raw: dict[str, Any]) -> CandidatePolicyMetadata:
+        detector_confidence = _first_present(
+            raw,
+            ("detector_confidence", "confidence", "score"),
+        )
+        return cls(
+            event_class=str(raw.get("event_class") or raw.get("class_name") or "").strip(),
+            detector_label=_optional_str(raw.get("detector_label") or raw.get("raw_label")),
+            detector_confidence=_optional_float(detector_confidence),
+            zone_ids=tuple(str(z).strip() for z in raw.get("zone_ids", []) if str(z).strip()),
+            stream_id=_optional_str(raw.get("stream_id")),
+            camera_id=_optional_str(raw.get("camera_id")),
+            site_id=_optional_str(raw.get("site_id")),
+            track_id=raw.get("track_id"),
+            start_pts_s=_optional_float(raw.get("start_pts_s")),
+            peak_pts_s=_optional_float(raw.get("peak_pts_s")),
+            keyframe_pts=tuple(float(v) for v in raw.get("keyframe_pts", [])),
+            extra=dict(raw.get("extra") or {}),
+        )
+
+
+@dataclass(frozen=True)
+class ScenarioPolicyMatch:
+    policy_pack: PolicyPack
+    scenario: ScenarioPolicy
+
+
+class ScenarioPolicyRouter:
+    """Match detector candidates to verifier scenario policies."""
+
+    def __init__(self, policy_packs: list[PolicyPack] | tuple[PolicyPack, ...] | PolicyPack):
+        if isinstance(policy_packs, PolicyPack):
+            policy_packs = [policy_packs]
+        self.policy_packs = tuple(policy_packs)
+
+    def match(
+        self, candidate: CandidateAlert | CandidatePolicyMetadata | dict[str, Any]
+    ) -> ScenarioPolicyMatch | None:
+        meta = normalize_candidate_metadata(candidate)
+        if not meta.event_class:
+            return None
+        for pack in self.policy_packs:
+            for scenario in pack.scenarios:
+                if _scenario_matches(scenario, meta):
+                    return ScenarioPolicyMatch(policy_pack=pack, scenario=scenario)
+        return None
+
+
+def normalize_candidate_metadata(
+    candidate: CandidateAlert | CandidatePolicyMetadata | dict[str, Any],
+) -> CandidatePolicyMetadata:
+    if isinstance(candidate, CandidatePolicyMetadata):
+        return candidate
+    if isinstance(candidate, CandidateAlert):
+        return CandidatePolicyMetadata.from_candidate_alert(candidate)
+    if isinstance(candidate, dict):
+        return CandidatePolicyMetadata.from_mapping(candidate)
+    raise TypeError(f"unsupported candidate metadata type: {type(candidate)!r}")
+
+
+def _scenario_matches(scenario: ScenarioPolicy, meta: CandidatePolicyMetadata) -> bool:
+    if scenario.event_class != meta.event_class:
+        return False
+
+    if (
+        meta.detector_confidence is not None
+        and float(meta.detector_confidence) < scenario.min_detector_confidence
+    ):
+        return False
+
+    if meta.detector_label:
+        label = meta.detector_label.strip()
+        if (
+            label not in scenario.detector_labels
+            and meta.event_class not in scenario.detector_labels
+        ):
+            return False
+
+    zones = set(meta.zone_ids)
+    if scenario.zones.exclude and zones.intersection(scenario.zones.exclude):
+        return False
+    return not (scenario.zones.include and not zones.intersection(scenario.zones.include))
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _first_present(raw: dict[str, Any], keys: tuple[str, ...]) -> Any:
+    for key in keys:
+        if key in raw:
+            return raw[key]
+    return None

--- a/vrs/policy/schema.py
+++ b/vrs/policy/schema.py
@@ -1,0 +1,205 @@
+"""Structured scenario verifier policy contracts.
+
+These dataclasses intentionally describe verifier reasoning policy, not the
+detector watch list.  A policy pack can be versioned, reviewed, diffed, and
+rendered into verifier prompts without creating one-off customer prompt files.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+DEFAULT_DECISION_LABELS = ("true_alert", "false_positive", "uncertain")
+
+
+@dataclass(frozen=True)
+class ZoneRules:
+    """Zone include/exclude constraints for a scenario."""
+
+    include: tuple[str, ...] = ()
+    exclude: tuple[str, ...] = ()
+
+    @classmethod
+    def from_mapping(cls, raw: dict[str, Any] | None) -> ZoneRules:
+        raw = raw or {}
+        return cls(
+            include=tuple(_string_list(raw.get("include"), "zones.include")),
+            exclude=tuple(_string_list(raw.get("exclude"), "zones.exclude")),
+        )
+
+
+@dataclass(frozen=True)
+class VerifierPolicy:
+    """Verifier output controls for a scenario."""
+
+    enabled: bool = True
+    require_json: bool = True
+    decision_labels: tuple[str, ...] = DEFAULT_DECISION_LABELS
+
+    @classmethod
+    def from_mapping(cls, raw: dict[str, Any] | None) -> VerifierPolicy:
+        raw = raw or {}
+        labels = raw.get("decision_labels", DEFAULT_DECISION_LABELS)
+        labels_out = tuple(_string_list(labels, "verifier.decision_labels"))
+        if not labels_out:
+            raise ValueError("verifier.decision_labels must not be empty")
+        return cls(
+            enabled=bool(raw.get("enabled", True)),
+            require_json=bool(raw.get("require_json", True)),
+            decision_labels=labels_out,
+        )
+
+
+@dataclass(frozen=True)
+class ScenarioPolicy:
+    """One scenario-specific interpretation of a coarse detector event class."""
+
+    id: str
+    event_class: str
+    detector_labels: tuple[str, ...]
+    prompt_template: str
+    context_window_s: float
+    min_detector_confidence: float
+    normal_conditions: tuple[str, ...] = ()
+    abnormal_conditions: tuple[str, ...] = ()
+    false_positive_hints: tuple[str, ...] = ()
+    true_positive_hints: tuple[str, ...] = ()
+    required_evidence: tuple[str, ...] = ()
+    uncertain_when: tuple[str, ...] = ()
+    zones: ZoneRules = field(default_factory=ZoneRules)
+    severity: dict[str, str] = field(default_factory=dict)
+    recommended_action: dict[str, str] = field(default_factory=dict)
+    verifier: VerifierPolicy = field(default_factory=VerifierPolicy)
+
+    @classmethod
+    def from_mapping(cls, raw: dict[str, Any]) -> ScenarioPolicy:
+        if not isinstance(raw, dict):
+            raise ValueError("scenario entries must be mappings")
+
+        scenario_id = _required_str(raw, "id")
+        event_class = _required_str(raw, "event_class")
+        detector_labels = tuple(
+            _string_list(raw.get("detector_labels") or [event_class], "detector_labels")
+        )
+        if not detector_labels:
+            raise ValueError(f"scenario[{scenario_id}].detector_labels must not be empty")
+
+        context_window_s = float(raw.get("context_window_s", 4.0))
+        if context_window_s <= 0:
+            raise ValueError(f"scenario[{scenario_id}].context_window_s must be > 0")
+
+        min_detector_confidence = float(raw.get("min_detector_confidence", 0.0))
+        if not 0.0 <= min_detector_confidence <= 1.0:
+            raise ValueError(f"scenario[{scenario_id}].min_detector_confidence must be in [0, 1]")
+
+        return cls(
+            id=scenario_id,
+            event_class=event_class,
+            detector_labels=detector_labels,
+            prompt_template=_required_str(raw, "prompt_template"),
+            context_window_s=context_window_s,
+            min_detector_confidence=min_detector_confidence,
+            normal_conditions=tuple(
+                _string_list(raw.get("normal_conditions"), "normal_conditions")
+            ),
+            abnormal_conditions=tuple(
+                _string_list(raw.get("abnormal_conditions"), "abnormal_conditions")
+            ),
+            false_positive_hints=tuple(
+                _string_list(raw.get("false_positive_hints"), "false_positive_hints")
+            ),
+            true_positive_hints=tuple(
+                _string_list(raw.get("true_positive_hints"), "true_positive_hints")
+            ),
+            required_evidence=tuple(
+                _string_list(raw.get("required_evidence"), "required_evidence")
+            ),
+            uncertain_when=tuple(_string_list(raw.get("uncertain_when"), "uncertain_when")),
+            zones=ZoneRules.from_mapping(raw.get("zones")),
+            severity=_string_mapping(raw.get("severity"), "severity"),
+            recommended_action=_string_mapping(raw.get("recommended_action"), "recommended_action"),
+            verifier=VerifierPolicy.from_mapping(raw.get("verifier")),
+        )
+
+    def severity_for(self, verdict: str) -> str | None:
+        return self.severity.get(verdict)
+
+    def recommended_action_for(self, verdict: str) -> str | None:
+        return self.recommended_action.get(verdict)
+
+
+@dataclass(frozen=True)
+class PolicyPack:
+    """A versioned pack of verifier scenario policies."""
+
+    policy_id: str
+    policy_version: int
+    scenarios: tuple[ScenarioPolicy, ...]
+    description: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, raw: dict[str, Any]) -> PolicyPack:
+        if not isinstance(raw, dict):
+            raise ValueError("policy pack must be a mapping")
+
+        policy_id = _required_str(raw, "policy_id")
+        policy_version = int(raw.get("policy_version", 1))
+        if policy_version < 1:
+            raise ValueError("policy_version must be >= 1")
+
+        scenarios_raw = raw.get("scenarios") or []
+        if not isinstance(scenarios_raw, list) or not scenarios_raw:
+            raise ValueError("policy pack must contain at least one scenario")
+        scenarios = tuple(ScenarioPolicy.from_mapping(item) for item in scenarios_raw)
+
+        seen: set[str] = set()
+        for scenario in scenarios:
+            if scenario.id in seen:
+                raise ValueError(f"duplicate scenario id: {scenario.id!r}")
+            seen.add(scenario.id)
+
+        metadata = raw.get("metadata") or {}
+        if not isinstance(metadata, dict):
+            raise ValueError("metadata must be a mapping when provided")
+
+        return cls(
+            policy_id=policy_id,
+            policy_version=policy_version,
+            scenarios=scenarios,
+            description=str(raw.get("description", "")).strip(),
+            metadata=dict(metadata),
+        )
+
+    def get_scenario(self, scenario_id: str) -> ScenarioPolicy | None:
+        for scenario in self.scenarios:
+            if scenario.id == scenario_id:
+                return scenario
+        return None
+
+
+def _required_str(raw: dict[str, Any], key: str) -> str:
+    value = str(raw.get(key, "")).strip()
+    if not value:
+        raise ValueError(f"missing required field {key!r}")
+    return value
+
+
+def _string_list(value: Any, name: str) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, list | tuple):
+        raise ValueError(f"{name} must be a string or list of strings")
+    out = [str(item).strip() for item in value if str(item).strip()]
+    return out
+
+
+def _string_mapping(value: Any, name: str) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must be a mapping")
+    return {str(k).strip(): str(v).strip() for k, v in value.items() if str(k).strip()}


### PR DESCRIPTION
## Summary

Adds the first scenario-aware verifier policy layer for structured, versioned policy packs:

- Adds policy pack schema/loading, scenario routing, and Markdown prompt rendering under `vrs/policy/`.
- Adds reusable verifier prompt templates with strict JSON output requirements.
- Adds factory fire-safety and elderly-care example policy packs.
- Adds CPU-only tests for YAML loading, scenario matching, CandidateAlert metadata normalization, and prompt rendering.

This is additive and keeps detector watch policy and verifier backend execution separate.

## Validation

- `python -m ruff check vrs/policy tests/test_scenario_policy.py`
- `python -m pytest tests/test_scenario_policy.py -q`
- `python -m pytest -q` (183 passed)
