### PR TITLE
feat(eval): add D-Fire dataset adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,45 @@ vrs/
 `scripts/eval.py` writes `<out>/report.json` using the stable schema version
 `vrs.eval.report.v1`.
 
+### Dataset Layouts
+
+The generic `labeled_dir` adapter expects MP4 files with optional sidecar JSON
+labels, as documented in `vrs/eval/datasets/labeled_dir.py`.
+
+The D-Fire adapter expects a local image dataset in YOLO format:
+
+```text
+datasets/dfire-mini/
+  images/
+    sample.jpg
+    quiet.jpg
+  labels/
+    sample.txt
+```
+
+Each label file uses one object per line:
+
+```text
+<class_id> <x_center> <y_center> <width> <height>
+```
+
+Coordinates are normalized to `0..1`. Missing label files are treated as quiet
+images. The default D-Fire class mapping is `0=smoke`, `1=fire`. D-Fire runs
+score bbox localization by default; pass `--bbox-scoring image` to collapse
+multiple boxes into class-present image-level metrics.
+
+Run a detector-only eval over a local D-Fire layout with:
+
+```bash
+uv run scripts/eval.py \
+  --dataset datasets/dfire-mini \
+  --dataset-format dfire \
+  --config configs/default.yaml \
+  --policy configs/policies/safety.yaml \
+  --mode detector_only \
+  --out runs/eval-dfire-detector
+```
+
 Top-level sections:
 - `schema_version` — explicit report-contract identifier for compatibility checks.
 - `run` — dataset name, run ID, timestamp, mode, and config/policy paths.
@@ -323,9 +362,9 @@ Top-level sections:
 - `quality_signals` — verifier flip rate, false-negative flag rate, and reserved diagnostic slots.
 - `per_video` — optional per-clip breakdown using the same metrics/quality shape.
 
-Today the CLI emits `mode: "full_cascade"` for the current detector+verifier
-path. A future detector-only scoring mode can reuse the same report schema with
-`mode: "detector_only"` instead of changing the JSON contract again.
+The CLI emits `mode: "full_cascade"` for the detector+verifier path and
+`mode: "detector_only"` when the verifier is disabled; both use the same JSON
+contract.
 
 `run.created_at` and `runtime.*` are diagnostic — they vary across runs and
 machines and are not part of the regression contract. The CI gate

--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -22,14 +22,20 @@ from pathlib import Path
 
 from vrs import setup_logging
 from vrs.eval import EvalReport, config_for_eval_mode, evaluate
-from vrs.eval.datasets import LabeledDirDataset
+from vrs.eval.datasets import DFireDataset, LabeledDirDataset
 
 logger = logging.getLogger(__name__)
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(description="VRS — evaluate the cascade on a labeled dataset")
-    ap.add_argument("--dataset", required=True, help="labeled dataset root (see LabeledDirDataset)")
+    ap.add_argument("--dataset", required=True, help="dataset root")
+    ap.add_argument(
+        "--dataset-format",
+        choices=("labeled_dir", "dfire"),
+        default="labeled_dir",
+        help="dataset adapter to use",
+    )
     ap.add_argument("--config", default="configs/default.yaml")
     ap.add_argument("--policy", default="configs/policies/safety.yaml")
     ap.add_argument(
@@ -45,6 +51,18 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=1.0,
         help="temporal slack around GT event windows when matching alerts",
     )
+    ap.add_argument(
+        "--bbox-iou-threshold",
+        type=float,
+        default=0.5,
+        help="IoU threshold for bbox datasets such as D-Fire",
+    )
+    ap.add_argument(
+        "--bbox-scoring",
+        choices=("bbox", "image"),
+        default="bbox",
+        help="score bbox datasets by object IoU or image-level class presence",
+    )
     ap.add_argument("--report", default=None, help="JSON report path (default: <out>/report.json)")
     return ap
 
@@ -57,7 +75,7 @@ def main(argv: list[str] | None = None) -> None:
     from vrs.pipeline import VRSPipeline, load_config
     from vrs.policy import load_watch_policy
 
-    dataset = LabeledDirDataset(args.dataset)
+    dataset = _load_dataset(args.dataset_format, args.dataset)
     verifier_enabled = False if args.mode == "detector_only" else None
     config = config_for_eval_mode(
         load_config(args.config, verifier_enabled=verifier_enabled),
@@ -73,6 +91,8 @@ def main(argv: list[str] | None = None) -> None:
         pipeline_factory=_factory,
         out_dir=args.out,
         tolerance_s=args.tolerance_s,
+        bbox_iou_threshold=args.bbox_iou_threshold,
+        bbox_scoring=args.bbox_scoring,
     )
 
     report_path = Path(args.report) if args.report else Path(args.out) / "report.json"
@@ -103,6 +123,14 @@ def main(argv: list[str] | None = None) -> None:
             f"P={d['precision']:.3f}  R={d['recall']:.3f}  F1={d['f1']:.3f}"
         )
     print(f"\nReport: {report_path}")
+
+
+def _load_dataset(dataset_format: str, root: str):
+    if dataset_format == "dfire":
+        return DFireDataset(root)
+    if dataset_format == "labeled_dir":
+        return LabeledDirDataset(root)
+    raise ValueError(f"unknown dataset format: {dataset_format!r}")
 
 
 if __name__ == "__main__":

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
+from PIL import Image
 
 from vrs.eval import (
     SCHEMA_VERSION,
@@ -16,8 +17,10 @@ from vrs.eval import (
     HarnessResult,
     config_for_eval_mode,
     score_alerts_against_truth,
+    score_detections_against_truth,
+    score_image_level_against_truth,
 )
-from vrs.eval.datasets import LabeledDirDataset
+from vrs.eval.datasets import DFireDataset, LabeledDirDataset
 from vrs.eval.metrics import aggregate_scores
 
 
@@ -34,6 +37,10 @@ def _alert(
 
 def _event(cls: str, start: float, end: float) -> GroundTruthEvent:
     return GroundTruthEvent(class_name=cls, start_s=start, end_s=end)
+
+
+def _bbox_event(cls: str, bbox: tuple[float, float, float, float]) -> GroundTruthEvent:
+    return GroundTruthEvent(class_name=cls, start_s=0.0, end_s=0.0, bbox_xywh_norm=bbox)
 
 
 # ─── ClassMetrics ──────────────────────────────────────────────────────
@@ -142,6 +149,69 @@ def test_score_restricted_classes_excludes_others():
     assert score.n_events == 0
 
 
+def test_score_detections_matches_bboxes_by_class_and_iou():
+    alerts = [
+        {
+            "class_name": "fire",
+            "peak_pts_s": 0.0,
+            "true_alert": True,
+            "bbox_xywh_norm": [0.50, 0.50, 0.40, 0.40],
+        },
+        {
+            "class_name": "smoke",
+            "peak_pts_s": 0.0,
+            "true_alert": True,
+            "bbox_xywh_norm": [0.10, 0.10, 0.10, 0.10],
+        },
+    ]
+    events = [
+        _bbox_event("fire", (0.50, 0.50, 0.40, 0.40)),
+        _bbox_event("smoke", (0.80, 0.80, 0.10, 0.10)),
+    ]
+
+    score = score_detections_against_truth(alerts, events, iou_threshold=0.5)
+
+    assert (score.per_class["fire"].tp, score.per_class["fire"].fp, score.per_class["fire"].fn) == (
+        1,
+        0,
+        0,
+    )
+    assert (
+        score.per_class["smoke"].tp,
+        score.per_class["smoke"].fp,
+        score.per_class["smoke"].fn,
+    ) == (0, 1, 1)
+
+
+def test_score_detections_uses_peak_detection_xyxy_boxes():
+    alerts = [
+        {
+            "class_name": "smoke",
+            "peak_pts_s": 0.0,
+            "true_alert": True,
+            "peak_detections": [{"score": 0.9, "xyxy": [20, 10, 60, 30]}],
+        }
+    ]
+    events = [_bbox_event("smoke", (0.40, 0.40, 0.40, 0.40))]
+
+    score = score_detections_against_truth(alerts, events, image_size=(100, 50))
+
+    assert score.per_class["smoke"].tp == 1
+
+
+def test_score_image_level_collapses_multiple_boxes_to_class_presence():
+    alerts = [_alert("fire", 0.0), _alert("smoke", 0.0)]
+    events = [
+        _bbox_event("fire", (0.2, 0.2, 0.1, 0.1)),
+        _bbox_event("fire", (0.8, 0.8, 0.1, 0.1)),
+    ]
+
+    score = score_image_level_against_truth(alerts, events)
+
+    assert (score.per_class["fire"].tp, score.per_class["fire"].fn) == (1, 0)
+    assert score.per_class["smoke"].fp == 1
+
+
 # ─── aggregation ──────────────────────────────────────────────────────
 
 
@@ -183,6 +253,39 @@ def test_labeled_dir_yields_items_with_events(tmp_path: Path):
 def test_labeled_dir_rejects_nonexistent_root(tmp_path: Path):
     with pytest.raises(FileNotFoundError):
         LabeledDirDataset(tmp_path / "does-not-exist")
+
+
+def test_dfire_dataset_yields_image_items_with_bbox_events(tmp_path: Path):
+    root = tmp_path / "dfire-mini"
+    images = root / "images"
+    labels = root / "labels"
+    images.mkdir(parents=True)
+    labels.mkdir()
+
+    Image.new("RGB", (80, 40), color="black").save(images / "sample.jpg")
+    Image.new("RGB", (80, 40), color="black").save(images / "quiet.jpg")
+    (labels / "sample.txt").write_text("0 0.50 0.50 0.25 0.50\n1 0.25 0.25 0.20 0.20\n")
+
+    items = list(DFireDataset(root))
+
+    assert [item.video_path.name for item in items] == ["quiet.jpg", "sample.jpg"]
+    assert items[0].events == []
+    assert items[0].image_size == (80, 40)
+    assert items[1].events == [
+        GroundTruthEvent("smoke", 0.0, 0.0, (0.50, 0.50, 0.25, 0.50)),
+        GroundTruthEvent("fire", 0.0, 0.0, (0.25, 0.25, 0.20, 0.20)),
+    ]
+
+
+def test_dfire_dataset_rejects_malformed_label(tmp_path: Path):
+    root = tmp_path / "dfire-mini"
+    (root / "images").mkdir(parents=True)
+    (root / "labels").mkdir()
+    Image.new("RGB", (10, 10), color="black").save(root / "images" / "bad.jpg")
+    (root / "labels" / "bad.txt").write_text("0 0.5 0.5 0.0 0.2\n")
+
+    with pytest.raises(ValueError, match="width/height"):
+        list(DFireDataset(root))
 
 
 # ─── harness integration (stubbed pipeline) ────────────────────────────
@@ -255,6 +358,70 @@ def test_harness_scores_per_video_and_aggregates(tmp_path: Path):
     # to_dict is JSON-serializable — smoke-test the CLI report shape
     blob = json.dumps(result.to_dict())
     assert "aggregate" in blob and "per_video" in blob
+
+
+def test_harness_uses_bbox_scoring_for_dfire_dataset(tmp_path: Path):
+    from vrs.eval import evaluate
+
+    root = tmp_path / "dfire-mini"
+    images = root / "images"
+    labels = root / "labels"
+    images.mkdir(parents=True)
+    labels.mkdir()
+    Image.new("RGB", (100, 50), color="black").save(images / "frame.jpg")
+    (labels / "frame.txt").write_text("1 0.40 0.40 0.40 0.40\n")
+
+    alerts_per_video = {
+        "frame": [
+            {
+                "class_name": "fire",
+                "peak_pts_s": 100.0,
+                "true_alert": True,
+                "peak_detections": [{"score": 0.8, "xyxy": [20, 10, 60, 30]}],
+            }
+        ]
+    }
+
+    def factory(od):
+        return _StubPipeline(od, alerts_per_video)
+
+    result = evaluate(
+        dataset=DFireDataset(root),
+        pipeline_factory=factory,
+        out_dir=tmp_path / "out",
+        tolerance_s=0.0,
+        bbox_iou_threshold=0.5,
+    )
+
+    assert result.aggregate.per_class["fire"].tp == 1
+
+
+def test_harness_can_score_bbox_dataset_at_image_level(tmp_path: Path):
+    from vrs.eval import evaluate
+
+    root = tmp_path / "dfire-mini"
+    images = root / "images"
+    labels = root / "labels"
+    images.mkdir(parents=True)
+    labels.mkdir()
+    Image.new("RGB", (100, 50), color="black").save(images / "frame.jpg")
+    (labels / "frame.txt").write_text("1 0.40 0.40 0.40 0.40\n")
+
+    alerts_per_video = {
+        "frame": [_alert("fire", 0.0, true_alert=True)],
+    }
+
+    def factory(od):
+        return _StubPipeline(od, alerts_per_video)
+
+    result = evaluate(
+        dataset=DFireDataset(root),
+        pipeline_factory=factory,
+        out_dir=tmp_path / "out",
+        bbox_scoring="image",
+    )
+
+    assert (result.aggregate.per_class["fire"].tp, result.aggregate.per_class["fire"].fp) == (1, 0)
 
 
 def test_eval_report_round_trip_is_stable():
@@ -348,11 +515,17 @@ def test_eval_cli_accepts_detector_only_mode():
             "configs/policies/safety.yaml",
             "--mode",
             "detector_only",
+            "--dataset-format",
+            "dfire",
+            "--bbox-scoring",
+            "image",
             "--out",
             "runs/eval-detector",
         ]
     )
     assert args.mode == "detector_only"
+    assert args.dataset_format == "dfire"
+    assert args.bbox_scoring == "image"
 
 
 def test_detector_only_pipeline_construction_skips_verifier(monkeypatch, tmp_path: Path):

--- a/vrs/eval/__init__.py
+++ b/vrs/eval/__init__.py
@@ -5,22 +5,28 @@ knob (thresholds, prompts, verifier model, tracking) stops being guesswork.
 
 Current scope:
   * Dataclasses for ground-truth events and eval results (``schemas``).
-  * Per-class P/R/F1 + verifier-flip rate + FN-flag rate (``metrics``).
+  * Per-class P/R/F1 + verifier-flip rate + FN-flag rate (``metrics``),
+    including event-level, bbox-level, and image-level scoring.
   * Stable, versioned ``EvalReport`` JSON contract (``report``).
   * Harness that iterates a dataset → runs the cascade → scores
-    (``harness``), with the labeled-directory adapter under ``datasets``.
+    (``harness``), with labeled-directory and D-Fire adapters under
+    ``datasets``.
   * Regression gate that compares two reports and exits non-zero on F1
     drops beyond a tolerance (``ci``, run as ``python -m vrs.eval.ci``).
 
 Upcoming:
-  * ``datasets/dfire.py`` and ``datasets/le2i.py`` — real public datasets.
-  * Detector-only evaluation mode reusing the same report schema.
+  * ``datasets/le2i.py`` and other real public datasets.
 """
 
 from __future__ import annotations
 
-from .harness import EvalMode, HarnessResult, config_for_eval_mode, evaluate
-from .metrics import aggregate_scores, score_alerts_against_truth
+from .harness import BBoxScoringMode, EvalMode, HarnessResult, config_for_eval_mode, evaluate
+from .metrics import (
+    aggregate_scores,
+    score_alerts_against_truth,
+    score_detections_against_truth,
+    score_image_level_against_truth,
+)
 from .report import (
     SCHEMA_VERSION,
     EvalReport,
@@ -43,6 +49,7 @@ from .schemas import ClassMetrics, EvalItem, GroundTruthEvent, RunScore
 
 __all__ = [
     "SCHEMA_VERSION",
+    "BBoxScoringMode",
     "ClassMetrics",
     "EvalItem",
     "EvalMode",
@@ -63,4 +70,6 @@ __all__ = [
     "config_for_eval_mode",
     "evaluate",
     "score_alerts_against_truth",
+    "score_detections_against_truth",
+    "score_image_level_against_truth",
 ]

--- a/vrs/eval/datasets/__init__.py
+++ b/vrs/eval/datasets/__init__.py
@@ -8,6 +8,7 @@ to change.
 from __future__ import annotations
 
 from .base import Dataset
+from .dfire import DFireDataset
 from .labeled_dir import LabeledDirDataset
 
-__all__ = ["Dataset", "LabeledDirDataset"]
+__all__ = ["DFireDataset", "Dataset", "LabeledDirDataset"]

--- a/vrs/eval/datasets/dfire.py
+++ b/vrs/eval/datasets/dfire.py
@@ -1,0 +1,119 @@
+"""Adapter for the D-Fire image dataset.
+
+D-Fire labels are YOLO text files: one object per line as
+``<class_id> <x_center> <y_center> <width> <height>``, with all coordinates
+normalized to ``0..1``. The common D-Fire YOLO mapping is ``0=smoke`` and
+``1=fire``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+
+from PIL import Image
+
+from ..schemas import EvalItem, GroundTruthEvent
+from .base import Dataset
+
+DEFAULT_DFIRE_CLASSES = ("smoke", "fire")
+DEFAULT_IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".bmp", ".webp")
+
+
+class DFireDataset(Dataset):
+    """Iterate a local D-Fire-style ``images/`` + ``labels/`` directory."""
+
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        images_dir: str | Path = "images",
+        labels_dir: str | Path = "labels",
+        class_names: Sequence[str] = DEFAULT_DFIRE_CLASSES,
+        image_extensions: Sequence[str] = DEFAULT_IMAGE_EXTENSIONS,
+    ):
+        self.root = Path(root)
+        if not self.root.is_dir():
+            raise FileNotFoundError(f"{self.root} is not a directory")
+
+        self.images_dir = self.root / images_dir
+        self.labels_dir = self.root / labels_dir
+        if not self.images_dir.is_dir():
+            raise FileNotFoundError(f"{self.images_dir} is not a directory")
+        if not self.labels_dir.is_dir():
+            raise FileNotFoundError(f"{self.labels_dir} is not a directory")
+
+        self.class_names = tuple(str(name) for name in class_names)
+        if not self.class_names:
+            raise ValueError("class_names must not be empty")
+        self.image_extensions = {ext.lower() for ext in image_extensions}
+
+    def __iter__(self) -> Iterator[EvalItem]:
+        for image_path in sorted(self.images_dir.iterdir()):
+            if image_path.suffix.lower() not in self.image_extensions:
+                continue
+            with Image.open(image_path) as img:
+                image_size = img.size
+            yield EvalItem(
+                video_path=image_path,
+                events=_load_yolo_label(
+                    self.labels_dir / f"{image_path.stem}.txt",
+                    class_names=self.class_names,
+                ),
+                image_size=image_size,
+            )
+
+
+def _load_yolo_label(label_path: Path, *, class_names: Sequence[str]) -> list[GroundTruthEvent]:
+    if not label_path.exists():
+        return []
+
+    events: list[GroundTruthEvent] = []
+    for lineno, raw in enumerate(label_path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw.strip()
+        if not line:
+            continue
+
+        parts = line.split()
+        if len(parts) != 5:
+            raise ValueError(f"{label_path}:{lineno}: expected 5 YOLO fields, got {len(parts)}")
+
+        class_id = _parse_class_id(parts[0], label_path=label_path, lineno=lineno)
+        if class_id >= len(class_names):
+            raise ValueError(
+                f"{label_path}:{lineno}: class id {class_id} has no configured class name"
+            )
+
+        bbox = tuple(float(v) for v in parts[1:5])
+        _validate_bbox(bbox, label_path=label_path, lineno=lineno)
+        events.append(
+            GroundTruthEvent(
+                class_name=class_names[class_id],
+                start_s=0.0,
+                end_s=0.0,
+                bbox_xywh_norm=bbox,
+            )
+        )
+    return events
+
+
+def _parse_class_id(raw: str, *, label_path: Path, lineno: int) -> int:
+    try:
+        class_id = int(raw)
+    except ValueError as e:
+        raise ValueError(f"{label_path}:{lineno}: class id must be an integer") from e
+    if class_id < 0:
+        raise ValueError(f"{label_path}:{lineno}: class id must be non-negative")
+    return class_id
+
+
+def _validate_bbox(
+    bbox: tuple[float, float, float, float], *, label_path: Path, lineno: int
+) -> None:
+    x, y, w, h = bbox
+    if not all(0.0 <= v <= 1.0 for v in bbox):
+        raise ValueError(f"{label_path}:{lineno}: YOLO bbox values must be between 0 and 1")
+    if w <= 0.0 or h <= 0.0:
+        raise ValueError(f"{label_path}:{lineno}: YOLO bbox width/height must be positive")
+    if x - w / 2.0 < 0.0 or x + w / 2.0 > 1.0 or y - h / 2.0 < 0.0 or y + h / 2.0 > 1.0:
+        raise ValueError(f"{label_path}:{lineno}: YOLO bbox must fit inside the image")

--- a/vrs/eval/harness.py
+++ b/vrs/eval/harness.py
@@ -22,7 +22,12 @@ from pathlib import Path
 from typing import Any, Literal
 
 from .datasets.base import Dataset
-from .metrics import aggregate_scores, score_alerts_against_truth
+from .metrics import (
+    aggregate_scores,
+    score_alerts_against_truth,
+    score_detections_against_truth,
+    score_image_level_against_truth,
+)
 from .schemas import RunScore
 
 logger = logging.getLogger(__name__)
@@ -30,6 +35,7 @@ logger = logging.getLogger(__name__)
 
 PipelineFactory = Callable[[Path], Any]  # (out_dir) -> something with .run(source)
 EvalMode = Literal["full_cascade", "detector_only"]
+BBoxScoringMode = Literal["bbox", "image"]
 
 
 @dataclass
@@ -62,6 +68,8 @@ def evaluate(
     out_dir: str | Path,
     *,
     tolerance_s: float = 1.0,
+    bbox_iou_threshold: float = 0.5,
+    bbox_scoring: BBoxScoringMode = "bbox",
     alerts_filename: str = "alerts.jsonl",
     classes: Iterable[str] | None = None,
 ) -> HarnessResult:
@@ -74,10 +82,16 @@ def evaluate(
         out_dir: parent dir; each item gets its own subdir keyed by
             ``video_path.stem``.
         tolerance_s: temporal slack around ground-truth event windows.
+        bbox_iou_threshold: IoU threshold for image/bbox datasets.
+        bbox_scoring: score bbox-labeled sources by object IoU or image-level
+            class presence.
         alerts_filename: name of the JSONL the pipeline writes in its out dir.
         classes: restrict scoring to these class names (``None`` = union of
             classes seen in alerts / events).
     """
+    if bbox_scoring not in ("bbox", "image"):
+        raise ValueError(f"unknown bbox scoring mode: {bbox_scoring!r}")
+
     root = Path(out_dir)
     root.mkdir(parents=True, exist_ok=True)
 
@@ -95,12 +109,28 @@ def evaluate(
             logger.error("pipeline run failed on %s: %s", item.video_path, e)
 
         alerts = _load_alerts(video_out / alerts_filename)
-        score = score_alerts_against_truth(
-            alerts,
-            item.events,
-            tolerance_s=tolerance_s,
-            classes=classes_set,
-        )
+        if item.image_size is not None or any(e.bbox_xywh_norm is not None for e in item.events):
+            if bbox_scoring == "image":
+                score = score_image_level_against_truth(
+                    alerts,
+                    item.events,
+                    classes=classes_set,
+                )
+            else:
+                score = score_detections_against_truth(
+                    alerts,
+                    item.events,
+                    image_size=item.image_size,
+                    iou_threshold=bbox_iou_threshold,
+                    classes=classes_set,
+                )
+        else:
+            score = score_alerts_against_truth(
+                alerts,
+                item.events,
+                tolerance_s=tolerance_s,
+                classes=classes_set,
+            )
         per_video.append((item.video_path, score))
         logger.info(
             "scored %s — alerts=%d events=%d per_class=%s flip_rate=%.3f",

--- a/vrs/eval/metrics.py
+++ b/vrs/eval/metrics.py
@@ -1,4 +1,4 @@
-"""Scoring: match alerts.jsonl records against ground-truth events.
+"""Scoring: match alerts.jsonl records against ground truth.
 
 Matching is temporal and per-class. An alert at ``peak_pts_s`` for class X
 matches a ground-truth event for class X when::
@@ -13,6 +13,10 @@ Only alerts with ``true_alert=True`` count as positive predictions: that is
 the cascade's final output. Raw detector hits that the verifier flipped to
 ``false_alarm`` are *not* treated as FPs against ground truth — they are
 captured separately as ``flip_rate``.
+
+Image datasets can also use normalized bbox matching. In that mode, each
+positive detector output is matched to at most one ground-truth box of the same
+class when IoU is above the requested threshold.
 """
 
 from __future__ import annotations
@@ -90,6 +94,118 @@ def score_alerts_against_truth(
     return score
 
 
+def score_detections_against_truth(
+    alerts: Sequence[dict],
+    events: Sequence[GroundTruthEvent],
+    *,
+    image_size: tuple[int, int] | None = None,
+    iou_threshold: float = 0.5,
+    classes: Iterable[str] | None = None,
+) -> RunScore:
+    """Compute detector P/R/F1 with one-to-one bbox IoU matching.
+
+    Args:
+        alerts: decoded ``alerts.jsonl`` lines. Detector-only VRS alerts expose
+            boxes either as ``bbox_xywh_norm`` or as ``peak_detections[].xyxy``.
+        events: ground-truth objects for the same image/source. Events without
+            ``bbox_xywh_norm`` are ignored by this scorer.
+        image_size: ``(width, height)`` used to normalize ``xyxy`` detector
+            boxes from ``peak_detections``.
+        iou_threshold: minimum same-class IoU for a TP.
+        classes: restrict scoring to these class names. Defaults to the union
+            of classes that appear in predictions or ground truth.
+    """
+    if not 0.0 <= iou_threshold <= 1.0:
+        raise ValueError("iou_threshold must be between 0 and 1")
+
+    predictions = list(_iter_detection_predictions(alerts, image_size=image_size))
+    gt = [e for e in events if e.bbox_xywh_norm is not None]
+
+    if classes is None:
+        classes = {p[0] for p in predictions} | {e.class_name for e in gt}
+    class_set = set(classes)
+
+    score = RunScore()
+    for a in alerts:
+        score.n_alerts_total += 1
+        if a.get("true_alert", True):
+            score.n_alerts_true += 1
+        if a.get("false_negative_class"):
+            score.n_fn_flagged += 1
+
+    score.n_events = sum(1 for e in gt if e.class_name in class_set)
+
+    for cls in class_set:
+        cm = ClassMetrics()
+        cls_events = [e for e in gt if e.class_name == cls]
+        matched = [False] * len(cls_events)
+
+        cls_predictions = [p for p in predictions if p[0] == cls]
+        for _, pred_box in sorted(cls_predictions, key=lambda p: p[1]):
+            hit_idx = None
+            hit_iou = iou_threshold
+            for i, ev in enumerate(cls_events):
+                if matched[i] or ev.bbox_xywh_norm is None:
+                    continue
+                iou = _iou_xywh_norm(pred_box, ev.bbox_xywh_norm)
+                if iou >= hit_iou:
+                    hit_idx = i
+                    hit_iou = iou
+            if hit_idx is None:
+                cm.fp += 1
+            else:
+                cm.tp += 1
+                matched[hit_idx] = True
+
+        cm.fn = matched.count(False)
+        score.per_class[cls] = cm
+
+    return score
+
+
+def score_image_level_against_truth(
+    alerts: Sequence[dict],
+    events: Sequence[GroundTruthEvent],
+    *,
+    classes: Iterable[str] | None = None,
+) -> RunScore:
+    """Compute image-level class presence metrics from bbox-labeled sources.
+
+    Multiple boxes or detections of the same class in one image count as one
+    class-present decision. This is useful for quick detector smoke tests where
+    localization quality is not being scored.
+    """
+    predicted = {a["class_name"] for a in alerts if a.get("true_alert", True)}
+    actual = {e.class_name for e in events}
+
+    if classes is None:
+        classes = predicted | actual
+    class_set = set(classes)
+
+    score = RunScore()
+    for a in alerts:
+        score.n_alerts_total += 1
+        if a.get("true_alert", True):
+            score.n_alerts_true += 1
+        if a.get("false_negative_class"):
+            score.n_fn_flagged += 1
+    score.n_events = sum(1 for cls in class_set if cls in actual)
+
+    for cls in class_set:
+        cm = ClassMetrics()
+        has_pred = cls in predicted
+        has_truth = cls in actual
+        if has_pred and has_truth:
+            cm.tp = 1
+        elif has_pred:
+            cm.fp = 1
+        elif has_truth:
+            cm.fn = 1
+        score.per_class[cls] = cm
+
+    return score
+
+
 def aggregate_scores(scores: Iterable[RunScore]) -> RunScore:
     """Sum per-class counts and totals across many per-video ``RunScore`` objects.
 
@@ -109,3 +225,87 @@ def aggregate_scores(scores: Iterable[RunScore]) -> RunScore:
             bucket.fp += cm.fp
             bucket.fn += cm.fn
     return agg
+
+
+def _iter_detection_predictions(
+    alerts: Sequence[dict],
+    *,
+    image_size: tuple[int, int] | None,
+) -> Iterable[tuple[str, tuple[float, float, float, float]]]:
+    for alert in alerts:
+        if not alert.get("true_alert", True):
+            continue
+
+        class_name = str(alert["class_name"])
+        bbox = alert.get("bbox_xywh_norm")
+        if bbox is not None:
+            yield class_name, _coerce_xywh_norm(bbox)
+            continue
+
+        for detection in alert.get("peak_detections", []) or []:
+            det_class = str(detection.get("class_name", class_name))
+            det_bbox = detection.get("bbox_xywh_norm")
+            if det_bbox is not None:
+                yield det_class, _coerce_xywh_norm(det_bbox)
+                continue
+
+            xyxy = detection.get("xyxy")
+            if xyxy is not None:
+                if image_size is None:
+                    raise ValueError("image_size is required to score peak_detections xyxy boxes")
+                yield det_class, _xyxy_pixels_to_xywh_norm(xyxy, image_size)
+
+
+def _coerce_xywh_norm(raw: Sequence[float]) -> tuple[float, float, float, float]:
+    if len(raw) != 4:
+        raise ValueError(f"expected 4 bbox coordinates, got {len(raw)}")
+    x, y, w, h = (float(v) for v in raw)
+    return (x, y, w, h)
+
+
+def _xyxy_pixels_to_xywh_norm(
+    raw: Sequence[float], image_size: tuple[int, int]
+) -> tuple[float, float, float, float]:
+    if len(raw) != 4:
+        raise ValueError(f"expected 4 bbox coordinates, got {len(raw)}")
+    width, height = image_size
+    if width <= 0 or height <= 0:
+        raise ValueError("image_size must contain positive width and height")
+
+    x1, y1, x2, y2 = (float(v) for v in raw)
+    return (
+        ((x1 + x2) / 2.0) / width,
+        ((y1 + y2) / 2.0) / height,
+        max(0.0, x2 - x1) / width,
+        max(0.0, y2 - y1) / height,
+    )
+
+
+def _iou_xywh_norm(
+    a: tuple[float, float, float, float],
+    b: tuple[float, float, float, float],
+) -> float:
+    ax1, ay1, ax2, ay2 = _xywh_to_xyxy(a)
+    bx1, by1, bx2, by2 = _xywh_to_xyxy(b)
+
+    ix1 = max(ax1, bx1)
+    iy1 = max(ay1, by1)
+    ix2 = min(ax2, bx2)
+    iy2 = min(ay2, by2)
+    iw = max(0.0, ix2 - ix1)
+    ih = max(0.0, iy2 - iy1)
+    intersection = iw * ih
+    if intersection <= 0.0:
+        return 0.0
+
+    area_a = max(0.0, ax2 - ax1) * max(0.0, ay2 - ay1)
+    area_b = max(0.0, bx2 - bx1) * max(0.0, by2 - by1)
+    union = area_a + area_b - intersection
+    return intersection / union if union > 0.0 else 0.0
+
+
+def _xywh_to_xyxy(box: tuple[float, float, float, float]) -> tuple[float, float, float, float]:
+    x, y, w, h = box
+    half_w = w / 2.0
+    half_h = h / 2.0
+    return (x - half_w, y - half_h, x + half_w, y + half_h)

--- a/vrs/eval/schemas.py
+++ b/vrs/eval/schemas.py
@@ -1,10 +1,9 @@
 """Data contracts for the eval harness.
 
-Ground truth is event-level (class name + time window in the source video);
-this matches how Le2i / UCF-Crime and the bulk of public VAD datasets label
-video, and is coarser than D-Fire's per-frame bboxes — a bbox-level scorer
-can be added later on top of the same ``GroundTruthEvent`` shape by adding a
-``bbox_xywh_norm`` field.
+Ground truth is event-level by default (class name + time window in the source
+video). Image datasets can attach a normalized YOLO-style bbox to the same
+object so detector-only eval can use IoU matching without changing the report
+contract.
 """
 
 from __future__ import annotations
@@ -15,19 +14,21 @@ from pathlib import Path
 
 @dataclass(frozen=True)
 class GroundTruthEvent:
-    """One labeled event in a source video."""
+    """One labeled event or image object in an eval source."""
 
     class_name: str
     start_s: float
     end_s: float
+    bbox_xywh_norm: tuple[float, float, float, float] | None = None
 
 
 @dataclass
 class EvalItem:
-    """One video + its ground-truth events (what a Dataset iterator yields)."""
+    """One source + its ground-truth events (what a Dataset iterator yields)."""
 
     video_path: Path
     events: list[GroundTruthEvent] = field(default_factory=list)
+    image_size: tuple[int, int] | None = None  # (width, height), for bbox scoring
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add a D-Fire YOLO-label dataset adapter for images/labels layouts
- support bbox IoU and image-level scoring for bbox-labeled eval items
- wire scripts/eval.py with dataset-format and bbox-scoring options
- document the expected D-Fire mini/full layout

## Tests
- uv run ruff check .
- uv run python -m pytest -q